### PR TITLE
Add support for FRI ver2.5

### DIFF
--- a/lbr_fri_ros2/CMakeLists.txt
+++ b/lbr_fri_ros2/CMakeLists.txt
@@ -7,13 +7,16 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(fri REQUIRED)
+# find_package(fri REQUIRED)
 find_package(lbr_fri_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(realtime_tools REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(urdf REQUIRED)
+
+# Add fri
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../fri/fri)
 
 # lbr_fri_ros2
 add_library(lbr_fri_ros2
@@ -30,14 +33,16 @@ target_include_directories(lbr_fri_ros2
 )
 
 ament_target_dependencies(lbr_fri_ros2
-  fri
+      # fri
   lbr_fri_msgs
   urdf
 )
 
+target_link_libraries(${PROJECT_NAME} PRIVATE fri)
+
 ament_export_targets(lbr_fri_ros2_export HAS_LIBRARY_TARGET)
 ament_export_dependencies(
-  fri
+  # fri
   lbr_fri_msgs
   urdf
 )
@@ -76,7 +81,7 @@ ament_target_dependencies(lbr_app_component
   rclcpp
   rclcpp_components
   realtime_tools
-  fri
+  # fri
   lbr_fri_msgs
 )
 

--- a/lbr_fri_ros2/include/lbr_fri_ros2/lbr_app.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/lbr_app.hpp
@@ -12,9 +12,9 @@
 #include "realtime_tools/realtime_buffer.h"
 #include "realtime_tools/realtime_publisher.h"
 
-#include "fri/friClientApplication.h"
-#include "fri/friClientIf.h"
-#include "fri/friUdpConnection.h"
+#include "friClientApplication.h"
+#include "friClientIf.h"
+#include "friUdpConnection.h"
 
 #include "lbr_fri_msgs/srv/app_connect.hpp"
 #include "lbr_fri_msgs/srv/app_disconnect.hpp"

--- a/lbr_fri_ros2/include/lbr_fri_ros2/lbr_client.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/lbr_client.hpp
@@ -4,8 +4,7 @@
 #include <memory>
 #include <stdexcept>
 
-#include "fri/friClientIf.h"
-#include "fri/friLBRClient.h"
+#include "friLBRClient.h"
 
 #include "lbr_fri_ros2/lbr_intermediary.hpp"
 

--- a/lbr_fri_ros2/include/lbr_fri_ros2/lbr_command_guard.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/lbr_command_guard.hpp
@@ -9,7 +9,7 @@
 
 #include "urdf/model.h"
 
-#include "fri/friClientIf.h"
+#include "friClientIf.h"
 
 #include "lbr_fri_msgs/msg/lbr_command.hpp"
 #include "lbr_fri_msgs/msg/lbr_state.hpp"

--- a/lbr_fri_ros2/include/lbr_fri_ros2/lbr_intermediary.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/lbr_intermediary.hpp
@@ -5,9 +5,9 @@
 #include <stdexcept>
 
 #include "fri/FRIMessages.pb.h"
-#include "fri/friClientIf.h"
-#include "fri/friLBRCommand.h"
-#include "fri/friLBRState.h"
+#include "friClientIf.h"
+#include "friLBRCommand.h"
+#include "friLBRState.h"
 
 #include "lbr_fri_msgs/msg/lbr_command.hpp"
 #include "lbr_fri_msgs/msg/lbr_state.hpp"

--- a/lbr_fri_ros2/src/lbr_command_guard.cpp
+++ b/lbr_fri_ros2/src/lbr_command_guard.cpp
@@ -35,7 +35,7 @@ bool LBRCommandGuard::is_valid_command(const lbr_fri_msgs::msg::LBRCommand &lbr_
   switch (lbr_state.client_command_mode) {
   case KUKA::FRI::EClientCommandMode::NO_COMMAND_MODE:
     return false;
-  case KUKA::FRI::EClientCommandMode::POSITION:
+  case KUKA::FRI::EClientCommandMode::JOINT_POSITION:
     if (is_nan_(lbr_command.joint_position.cbegin(), lbr_command.joint_position.cend())) {
       return false;
     }

--- a/lbr_fri_ros2/src/lbr_intermediary.cpp
+++ b/lbr_fri_ros2/src/lbr_intermediary.cpp
@@ -37,7 +37,7 @@ bool LBRIntermediary::buffer_to_command(KUKA::FRI::LBRCommand &lbr_command) cons
     switch (lbr_state_buffer_.client_command_mode) {
     case KUKA::FRI::EClientCommandMode::NO_COMMAND_MODE:
       return true;
-    case KUKA::FRI::EClientCommandMode::POSITION:
+    case KUKA::FRI::EClientCommandMode::JOINT_POSITION:
       lbr_command.setJointPosition(lbr_command_buffer_.joint_position.data());
       return true;
     case KUKA::FRI::EClientCommandMode::WRENCH:

--- a/lbr_hardware_interface/CMakeLists.txt
+++ b/lbr_hardware_interface/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(rclcpp REQUIRED)
 find_package(realtime_tools REQUIRED)
 find_package(lbr_fri_msgs REQUIRED)
 find_package(lbr_fri_ros2 REQUIRED)
-find_package(fri REQUIRED)
+# find_package(fri REQUIRED)
 
 # Define targets
 add_library(
@@ -26,6 +26,9 @@ add_library(
   SHARED
   src/lbr_hardware_interface.cpp
 )
+
+# Add fri sub directory
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../fri/fri)
 
 # Add include directories for target
 target_include_directories(
@@ -47,7 +50,7 @@ ament_target_dependencies(
   realtime_tools
   lbr_fri_msgs
   lbr_fri_ros2
-  fri
+  # fri
 )
 
 pluginlib_export_plugin_description_file(hardware_interface lbr_hardware_interface.xml)
@@ -65,8 +68,10 @@ ament_export_dependencies(
   realtime_tools
   lbr_fri_msgs
   lbr_fri_ros2
-  fri
+  # fri
 )
+
+target_link_libraries(${PROJECT_NAME} PUBLIC fri)
 
 install(
   DIRECTORY include/


### PR DESCRIPTION
This PR adds support for ver2.5. @mhubii I'm not sure how you want to handle this? Currently this overwrites the v1.15. So the PR is not ready to merge. Probably good to add a switch in the build somewhere so the user can specify which version they use. 

I would suggest creating a macro that specifies the FRI version, then use something like

```cpp
#if FRI_VERSION == 115
// v1.15 implementation
#elif FRI_VERSION == 25
// v2.5 implementation
#endif
```

Also, I am getting the error when building:

```
--- stderr: lbr_fri_ros2                                                              
CMake Error at CMakeLists.txt:19 (add_subdirectory):
  add_subdirectory not given a binary directory but the given source
  directory "/home/cm22/balgrist_ws/src/fri/fri" is not a subdirectory of
  "/home/cm22/balgrist_ws/src/lbr_fri_ros2_stack/lbr_fri_ros2".  When
  specifying an out-of-tree source a binary directory must be explicitly
  specified.


CMake Error at CMakeLists.txt:41 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "lbr_fri_ros2".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

  The uses of the plain signature are here:

   * /opt/ros/foxy/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:145 (target_link_libraries)



---

```

I think the issue is that I made the FRI package non-ament_cmake, so linking the library is not the same. Perhaps this is something you know better than me how to fix?

If you could let me know if you have any ideas re this issue above then I'll fix, and can do the macro support switch thing i mention above. However, for this I will also need to know how you want to handle the switch? Ie. where you think it should be placed?