### PR TITLE
Humble v2.0.0 Release

### DIFF
--- a/lbr_demos/lbr_demos_advanced_py/package.xml
+++ b/lbr_demos/lbr_demos_advanced_py/package.xml
@@ -5,6 +5,7 @@
   <version>2.0.0</version>
   <description>Advanced Python demos for the lbr_ros2_control.</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
+  <maintainer email="mower.chris@gmail.com">cmower</maintainer>
   <license>Apache License 2.0</license>
 
   <exec_depend>lbr_description</exec_depend>

--- a/lbr_demos/lbr_moveit_py/doc/lbr_moveit_py.rst
+++ b/lbr_demos/lbr_moveit_py/doc/lbr_moveit_py.rst
@@ -12,6 +12,21 @@ MoveIt via RViZ
 
 To run MoveIt via RViZ, simply follow:
 
+Simulation
+~~~~~~~~~~
+#. Run the robot driver:
+
+    .. code-block:: bash
+
+        ros2 launch lbr_bringup bringup.launch.py \
+            moveit:=true \
+            sim:=true \
+            model:=iiwa7 # [iiwa7, iiwa14, med7, med14]
+
+#. You can now move the robot via MoveIt in RViZ!
+
+Hardware
+~~~~~~~~
 #. Client side configurations:
 
     #. Configure the ``client_command_mode`` to ``position`` in `lbr_system_parameters.yaml <https://github.com/lbr-stack/lbr_fri_ros2_stack/blob/humble/lbr_ros2_control/config/lbr_system_parameters.yaml>`_:octicon:`link-external`
@@ -30,13 +45,4 @@ To run MoveIt via RViZ, simply follow:
         - ``FRI control mode``: ``POSITION_CONTROL`` or ``JOINT_IMPEDANCE_CONTROL``
         - ``FRI client command mode``: ``POSITION``
 
-#. Run the robot driver:
-
-    .. code-block:: bash
-
-        ros2 launch lbr_bringup bringup.launch.py \
-            moveit:=true \
-            sim:=false \
-            model:=iiwa7 # [iiwa7, iiwa14, med7, med14]
-
-#. You can now move the robot via MoveIt in RViZ!
+#. Proceed with steps 1 and 2 from `Simulation`_ but with ``sim:=false``.

--- a/lbr_fri_ros2/include/lbr_fri_ros2/filters.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/filters.hpp
@@ -126,20 +126,18 @@ protected:
   using pid_array_t = std::array<control_toolbox::Pid, KUKA::FRI::LBRState::NUMBER_OF_JOINTS>;
 
 public:
-  JointPIDArray() = default;
+  JointPIDArray() = delete;
+  JointPIDArray(const PIDParameters &pid_parameters);
 
   void compute(const value_array_t &command_target, const value_array_t &state,
                const std::chrono::nanoseconds &dt, value_array_t &command);
   void compute(const value_array_t &command_target, const double *state,
                const std::chrono::nanoseconds &dt, value_array_t &command);
-  void initialize(const PIDParameters &pid_parameters, const double &dt);
-  inline const bool &is_initialized() const { return initialized_; };
-
   void log_info() const;
 
 protected:
-  bool initialized_{false};     /**< True if initialized.*/
-  pid_array_t pid_controllers_; /**< PID controllers for each joint.*/
+  PIDParameters pid_parameters_; /**< PID parameters for all joints.*/
+  pid_array_t pid_controllers_;  /**< PID controllers for each joint.*/
 };
 } // end of namespace lbr_fri_ros2
 #endif // LBR_FRI_ROS2__FILTERS_HPP_

--- a/lbr_fri_ros2/include/lbr_fri_ros2/interfaces/base_command.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/interfaces/base_command.hpp
@@ -49,7 +49,6 @@ public:
 
 protected:
   std::unique_ptr<CommandGuard> command_guard_;
-  PIDParameters pid_parameters_;
   JointPIDArray joint_position_pid_;
   idl_command_t command_, command_target_;
 };

--- a/lbr_fri_ros2/src/interfaces/base_command.cpp
+++ b/lbr_fri_ros2/src/interfaces/base_command.cpp
@@ -5,7 +5,7 @@ namespace lbr_fri_ros2 {
 BaseCommandInterface::BaseCommandInterface(const PIDParameters &pid_parameters,
                                            const CommandGuardParameters &command_guard_parameters,
                                            const std::string &command_guard_variant)
-    : pid_parameters_(pid_parameters) {
+    : joint_position_pid_(pid_parameters) {
   command_guard_ = command_guard_factory(command_guard_parameters, command_guard_variant);
 };
 
@@ -18,13 +18,6 @@ void BaseCommandInterface::init_command(const_idl_state_t_ref state) {
 
 void BaseCommandInterface::log_info() const {
   command_guard_->log_info();
-  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME()), "*** Parameters:");
-  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME()), "*   pid.p: %.1f", pid_parameters_.p);
-  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME()), "*   pid.i: %.1f", pid_parameters_.i);
-  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME()), "*   pid.d: %.1f", pid_parameters_.d);
-  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME()), "*   pid.i_max: %.1f", pid_parameters_.i_max);
-  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME()), "*   pid.i_min: %.1f", pid_parameters_.i_min);
-  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME()), "*   pid.antiwindup: %s",
-              pid_parameters_.antiwindup ? "true" : "false");
+  joint_position_pid_.log_info();
 }
 } // namespace lbr_fri_ros2

--- a/lbr_fri_ros2/src/interfaces/position_command.cpp
+++ b/lbr_fri_ros2/src/interfaces/position_command.cpp
@@ -41,9 +41,6 @@ void PositionCommandInterface::buffered_command_to_fri(fri_command_t_ref command
   }
 
   // PID
-  if (!joint_position_pid_.is_initialized()) {
-    joint_position_pid_.initialize(pid_parameters_, state.sample_time);
-  }
   joint_position_pid_.compute(
       command_target_.joint_position, state.measured_joint_position,
       std::chrono::nanoseconds(static_cast<int64_t>(state.sample_time * 1.e9)),

--- a/lbr_fri_ros2/src/interfaces/torque_command.cpp
+++ b/lbr_fri_ros2/src/interfaces/torque_command.cpp
@@ -31,9 +31,6 @@ void TorqueCommandInterface::buffered_command_to_fri(fri_command_t_ref command,
   }
 
   // PID
-  if (!joint_position_pid_.is_initialized()) {
-    joint_position_pid_.initialize(pid_parameters_, state.sample_time);
-  }
   joint_position_pid_.compute(
       command_target_.joint_position, state.measured_joint_position,
       std::chrono::nanoseconds(static_cast<int64_t>(state.sample_time * 1.e9)),

--- a/lbr_fri_ros2/src/interfaces/wrench_command.cpp
+++ b/lbr_fri_ros2/src/interfaces/wrench_command.cpp
@@ -29,9 +29,6 @@ void WrenchCommandInterface::buffered_command_to_fri(fri_command_t_ref command,
   }
 
   // PID
-  if (!joint_position_pid_.is_initialized()) {
-    joint_position_pid_.initialize(pid_parameters_, state.sample_time);
-  }
   joint_position_pid_.compute(
       command_target_.joint_position, state.measured_joint_position,
       std::chrono::nanoseconds(static_cast<int64_t>(state.sample_time * 1.e9)),

--- a/lbr_moveit_config/doc/lbr_moveit_config.rst
+++ b/lbr_moveit_config/doc/lbr_moveit_config.rst
@@ -12,7 +12,7 @@ This procedure applies to all LBRs: ``iiwa7``, ``iiwa14``, ``med7``, and ``med14
 
     sudo apt install ros-$ROS_DISTRO-moveit*
 
-#. Make sure the ``lbr_fri_ros2_stack`` is installed and **sourced**, see :ref:`Installation`.
+#. Make sure the ``lbr-stack`` is installed and **sourced**, see :ref:`Installation`.
 
 #. Launch the setup assistant
 
@@ -20,7 +20,7 @@ This procedure applies to all LBRs: ``iiwa7``, ``iiwa14``, ``med7``, and ``med14
 
     ros2 launch moveit_setup_assistant setup_assistant.launch.py
 
-#. .. dropdown:: ``Load Files``: E.g. ``lbr_fri_ros2_stack_ws/install/lbr_description/share/lbr_description/urdf/iiwa7/iiwa7.xacro``
+#. .. dropdown:: ``Load Files``: E.g. ``lbr-stack/install/lbr_description/share/lbr_description/urdf/iiwa7/iiwa7.xacro``
 
     .. thumbnail:: img/00_start_screen.png
 
@@ -94,7 +94,7 @@ This procedure applies to all LBRs: ``iiwa7``, ``iiwa14``, ``med7``, and ``med14
 
 Update MoveIt Configuration 
 ---------------------------
-#. Make sure the ``lbr_fri_ros2_stack`` is installed and sourced, see :ref:`Installation`.
+#. Make sure the ``lbr-stack`` is installed and sourced, see :ref:`Installation`.
 
 #. Run the setup assistant for the existing configuration.
 

--- a/lbr_ros2_control/config/lbr_system_parameters.yaml
+++ b/lbr_ros2_control/config/lbr_system_parameters.yaml
@@ -7,7 +7,7 @@ hardware:
   port_id: 30200 # port id for the UDP communication. Useful in multi-robot setups
   remote_host: INADDR_ANY # the expected robot IP address. INADDR_ANY will accept any incoming connection
   rt_prio: 80 # real-time priority for the control loop
-  pid_p: 10.0 # P gain for the joint position  (useful for asynchronous control)
+  pid_p: 0.1 # P gain for the joint position  (useful for asynchronous control)
   pid_i: 0.0 # I gain for the joint position command
   pid_d: 0.0 # D gain for the joint position command
   pid_i_max: 0.0 # max integral value for the joint position command


### PR DESCRIPTION
Extension of https://github.com/lbr-stack/lbr_fri_ros2_stack/pull/174

This PR targets `2.0.0`. This will likely be the last major `humble` release and should pave the way for ROS index binaries. Following PRs will aim at `rolling`.

- Targeted release **14/04/2024**
- Much improved integrability
- Much improved testing
- Better demos

# Contributors
- https://github.com/lbr-stack/fri/pull/22: fredRocs
- https://github.com/lbr-stack/fri/pull/23: peterMitrano
- https://github.com/lbr-stack/fri/pull/18: bowangFromMars
- https://github.com/lbr-stack/fri/pull/27: OmidRezayof
- FRI 2.x testing: liver121888
- #151: Nicolai-98 
- #175: StephanSchwarz96

# Related PRs
- #158 
- #155 
- #151 
- #161 
- #170

# Issues Tracker

- #9 (following `1.5.0`)
- #163 
- #165 
- #172
- #159
- #189 
- #187 

# Desired Changes
- [x] Black linting
- [x] Fix link to docs
- [x] Velocity limit checks in impedance control mode
- [x] Matrix testing against multiple FRIs
- [x] ~~Add `${ROS_DISTRO}` to install instruction~~ (would require source, which renders it redundant) 
- [x] ~~Introduce node composition in launch files~~ to be done later
  Blockers:
  - `ros2_control` via composition: https://github.com/ros-controls/ros2_control/issues/1261
  - `rviz2` via composition: https://github.com/ros2/rviz/issues/1114
- [x] Add development tools dependency https://github.com/lbr-stack/lbr_fri_ros2_stack/issues/145
- [x] `ros2_control_node`: Read robot description from robot state publisher
- [x] ~~Use an event handler for robot state publisher~~ https://github.com/ros-controls/ros2_control/issues/1262
- [x] Add tests
  - [x] `lbr_fri_msgs`
  - [x] `lbr_fri_ros2` interface tests
- [x] De-couple interfaces by client command mode
- [ ] Update launch files
  - [x] Remove redundant nones from launch
  - [ ] De-couple launch files for simplified custom setups 
    - [ ] Add separate launch files for real / sim as no feature parity (would require Gazebo plugins)
    - [ ] Fix force torque broadcaster rviz config for simulation
    - [ ] Make separate moveit launch default
  - [x] Consider moving all launch mixins to `lbr_bringup`, or into `launch_mixins`, see https://github.com/mhubii/demo_launch
  - [ ] Add configurable static transform at launch, i.e. `world` -> `lbr/world`
  - [x] Remove `app.launch.py` from demos in favor for `ros2_control` variant (⚠️ breaking change)
- [x] Update documentation for `v1.4.x`
  - [x] Refer https://lbr-fri-ros2-stack-doc.readthedocs.io/en/latest/index.html
  - [x] Delete branches at https://github.com/lbr-stack/lbr_stack_doc in favor of tags
  - [x] Add an architecture chart to highlight relation to `ros2_control` in readme
- [x] Update parameter source for `gazebo_ros2_control` package in `lbr.gazebo.xacro`
- [x] Add coloring a la https://github.com/ros-controls/ros2_control/blob/e149646d3f2595f269cfa4e1cd0681abde89ee69/controller_manager/controller_manager/spawner.py#L45
- [x] De-couple the async client into position / torque / wrench
- [x] Update Docker for new sources
- [x] IDL changes: (⚠️ breaking change)
  - [x] `lbr_fri_msgs` -> `lbr_fri_idl`
  - [x] `LBRPositionCommand` -> `LBRJointPositionCommand`
- [ ] Build docs on PR: https://docs.readthedocs.io/en/stable/pull-requests.html
- [ ] Update link to server app in documentation
- [ ] Consider reading robot desriptions from topic rather than parameter where posssible

![FvnPq61X0AEbjNd](https://github.com/lbr-stack/lbr_fri_ros2_stack/assets/26366414/da696b27-efa8-4084-8a5f-b4aa7d195c25)

https://x.com/jdorfman/status/1655582823082782721?s=20
