### PR TITLE
Update TorqueCommandInterface - #232

### DIFF
--- a/lbr_fri_ros2/src/interfaces/torque_command.cpp
+++ b/lbr_fri_ros2/src/interfaces/torque_command.cpp
@@ -36,6 +36,9 @@ void TorqueCommandInterface::buffered_command_to_fri(fri_command_t_ref command,
   }
   joint_position_filter_.compute(command_target_.joint_position, command_.joint_position);
 
+  command_.torque = command_target_.torque;
+  command_.joint_position = command_target_.joint_position;
+
   // validate
   if (!command_guard_->is_valid_command(command_, state)) {
     std::string err = "Invalid command.";

--- a/lbr_fri_ros2/src/interfaces/torque_command.cpp
+++ b/lbr_fri_ros2/src/interfaces/torque_command.cpp
@@ -35,9 +35,7 @@ void TorqueCommandInterface::buffered_command_to_fri(fri_command_t_ref command,
     joint_position_filter_.initialize(state.sample_time);
   }
   joint_position_filter_.compute(command_target_.joint_position, command_.joint_position);
-
   command_.torque = command_target_.torque;
-  command_.joint_position = command_target_.joint_position;
 
   // validate
   if (!command_guard_->is_valid_command(command_, state)) {

--- a/lbr_fri_ros2/src/interfaces/wrench_command.cpp
+++ b/lbr_fri_ros2/src/interfaces/wrench_command.cpp
@@ -33,6 +33,7 @@ void WrenchCommandInterface::buffered_command_to_fri(fri_command_t_ref command,
     joint_position_filter_.initialize(state.sample_time);
   }
   joint_position_filter_.compute(command_target_.joint_position, command_.joint_position);
+  command_.wrench = command_target_.wrench;
 
   // validate
   if (!command_guard_->is_valid_command(command_, state)) {


### PR DESCRIPTION
Hi @mhubii, I added the modification of issue #232 for the torque control. I cannot test them in rolling since unfortunately a robot's fuse burned. Could you please test it? Ideally, the same changes should be applied [here](https://github.com/lbr-stack/lbr_fri_ros2_stack/blob/7c00ac916eb80fa356e885bed9631506a1601077/lbr_fri_ros2/src/interfaces/wrench_command.cpp#L36) for the wrench command.
