### PR TITLE
ign_ros2_control renamed to gz_ros2_control

### DIFF
--- a/lbr_bringup/package.xml
+++ b/lbr_bringup/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>ign_ros2_control</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>lbr_description</exec_depend>

--- a/lbr_description/gazebo/lbr_gazebo.xacro
+++ b/lbr_description/gazebo/lbr_gazebo.xacro
@@ -4,8 +4,8 @@
 
         <!-- ros_control-plugin -->
         <gazebo>
-            <plugin name="ign_ros2_control::IgnitionROS2ControlPlugin"
-                filename="ign_ros2_control-system">
+            <plugin name="gz_ros2_control::GazeboSimROS2ControlPlugin"
+                filename="gz_ros2_control-system">
                 <parameters>$(find lbr_description)/ros2_control/lbr_controllers.yaml</parameters>
                 <ros>
                     <namespace>/${robot_name}</namespace>

--- a/lbr_description/package.xml
+++ b/lbr_description/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_pytest</buildtool_depend>
 
-  <exec_depend>ign_ros2_control</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>

--- a/lbr_description/ros2_control/lbr_system_interface.xacro
+++ b/lbr_description/ros2_control/lbr_system_interface.xacro
@@ -15,7 +15,7 @@
             </xacro:if>
             <xacro:if value="${mode == 'gazebo'}">
                 <hardware>
-                    <plugin>ign_ros2_control/IgnitionSystem</plugin>
+                    <plugin>gz_ros2_control/GazeboSimSystem</plugin>
                 </hardware>
             </xacro:if>
             <xacro:if value="${mode == 'hardware'}">


### PR DESCRIPTION
Hi @mhubii,

we are using lbr_fri_ros2_stack for controlling KUKA robots in our lab at Czech Technical University. Seems that the ROS gazebo plugin was renamed from ign to gz also in humble, according the following warning, so I'm proposing this PR.

    [ruby $(which ign) gazebo-2] [WARN] [1751015042.468026535] [lbr.gz_ros2_control]: The ign_ros2_control plugin got renamed to gz_ros2_control.
    [ruby $(which ign) gazebo-2] Update the <ros2_control> tag and gazebo plugin to
    [ruby $(which ign) gazebo-2] <hardware>
    [ruby $(which ign) gazebo-2]   <plugin>gz_ros2_control/GazeboSimSystem</plugin>
    [ruby $(which ign) gazebo-2] </hardware>
    [ruby $(which ign) gazebo-2] <gazebo>
    [ruby $(which ign) gazebo-2]   <plugin filename="gz_ros2_control-System"name="gz_ros2_control::GazeboSimROS2ControlPlugin">
    [ruby $(which ign) gazebo-2]     ...
    [ruby $(which ign) gazebo-2]   </plugin>
    [ruby $(which ign) gazebo-2] </gazebo>
