### PR TITLE
Command-/StateInterface migration (#180)

### DIFF
--- a/lbr_fri_ros2/include/lbr_fri_ros2/types.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/types.hpp
@@ -32,6 +32,11 @@ using cart_array_t = std::array<double, CARTESIAN_DOF>;
 using cart_array_t_ref = cart_array_t &;
 using const_cart_array_t_ref = const cart_array_t &;
 
+// Cartesian names
+using cart_name_array_t = std::array<std::string, CARTESIAN_DOF>;
+using cart_name_array_t_ref = cart_name_array_t &;
+using const_cart_name_array_t_ref = const cart_name_array_t &;
+
 // FRI types
 using fri_command_t = KUKA::FRI::LBRCommand;
 using fri_command_t_ref = fri_command_t &;

--- a/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
@@ -218,6 +218,10 @@ protected:
   std::shared_ptr<lbr_fri_ros2::FTEstimatorImpl> ft_estimator_impl_ptr_;
   std::unique_ptr<lbr_fri_ros2::FTEstimator> ft_estimator_ptr_;
 
+  // command and state buffers
+  lbr_fri_idl::msg::LBRCommand lbr_command_;
+  lbr_fri_idl::msg::LBRState lbr_state_;
+
   // keys for command / state interfaces
   CommandKeys command_keys_;
   StateKeys state_keys_;

--- a/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
@@ -115,7 +115,7 @@ protected:
         velocity[i] = joint_name + "/" + hardware_interface::HW_IF_VELOCITY;
       }
 
-      sample_time = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TRACKING_PERFORMANCE;
+      sample_time = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SAMPLE_TIME;
       session_state = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SESSION_STATE;
       connection_quality = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONNECTION_QUALITY;
       safety_state = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SAFETY_STATE;

--- a/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
@@ -88,8 +88,6 @@ public:
   // hardware interface
   controller_interface::CallbackReturn
   on_init(const hardware_interface::HardwareComponentInterfaceParams &params) override;
-  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
-  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
   hardware_interface::return_type prepare_command_mode_switch(
       const std::vector<std::string> &start_interfaces,
@@ -135,42 +133,22 @@ protected:
   std::shared_ptr<lbr_fri_ros2::AsyncClient> async_client_ptr_;
   std::unique_ptr<lbr_fri_ros2::App> app_ptr_;
 
-  // exposed state interfaces (ideally these are taken from async_client_ptr_ but
-  // ros2_control ReadOnlyHandle does not allow for const pointers, refer
-  // https://github.com/ros-controls/ros2_control/issues/1196)
-  lbr_fri_idl::msg::LBRState hw_lbr_state_;
-
-  // exposed state interfaces that require casting
-  double hw_session_state_;
-  double hw_connection_quality_;
-  double hw_safety_state_;
-  double hw_operation_mode_;
-  double hw_drive_state_;
-  double hw_client_command_mode_;
-  double hw_overlay_type_;
-  double hw_control_mode_;
-  double hw_time_stamp_sec_;
-  double hw_time_stamp_nano_sec_;
-
-  // additional velocity state interface
-  lbr_fri_idl::msg::LBRState::_measured_joint_position_type last_hw_measured_joint_position_;
-  double last_hw_time_stamp_sec_;
-  double last_hw_time_stamp_nano_sec_;
-  lbr_fri_idl::msg::LBRState::_measured_joint_position_type hw_velocity_;
+  // velocity computation
+  lbr_fri_idl::msg::LBRState::_measured_joint_position_type last_measured_joint_position_,
+      velocity_;
+  double last_time_stamp_sec_;
+  double last_time_stamp_nano_sec_;
 
   // compute velocity for state interface
   double time_stamps_to_sec_(const double &sec, const double &nano_sec) const;
-  void nan_last_hw_states_();
-  void update_last_hw_states_();
-  void compute_hw_velocity_();
+  void nan_last_states_();
+  void update_last_states_();
+  void compute_velocity_();
 
   // additional force-torque state interface
-  lbr_fri_ros2::cart_array_t hw_ft_;
+  lbr_fri_ros2::cart_array_t ft_;
   std::shared_ptr<lbr_fri_ros2::FTEstimatorImpl> ft_estimator_impl_ptr_;
   std::unique_ptr<lbr_fri_ros2::FTEstimator> ft_estimator_ptr_;
-
-  // exposed command interfaces
-  lbr_fri_idl::msg::LBRCommand hw_lbr_command_;
 };
 } // namespace lbr_ros2_control
 #endif // LBR_ROS2_CONTROL__SYSTEM_INTERFACE_HPP_

--- a/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
@@ -32,43 +32,111 @@
 #include "lbr_ros2_control/system_interface_type_values.hpp"
 
 namespace lbr_ros2_control {
-struct SystemInterfaceParameters {
-  uint8_t fri_client_sdk_major_version{1};
-  uint8_t fri_client_sdk_minor_version{15};
+class SystemInterface : public hardware_interface::SystemInterface {
+protected:
+  struct SystemInterfaceParameters {
+    uint8_t fri_client_sdk_major_version{1};
+    uint8_t fri_client_sdk_minor_version{15};
 #if FRI_CLIENT_VERSION_MAJOR == 1
-  KUKA::FRI::EClientCommandMode client_command_mode{KUKA::FRI::EClientCommandMode::POSITION};
+    KUKA::FRI::EClientCommandMode client_command_mode{KUKA::FRI::EClientCommandMode::POSITION};
 #endif
 #if FRI_CLIENT_VERSION_MAJOR >= 2
-  KUKA::FRI::EClientCommandMode client_command_mode{KUKA::FRI::EClientCommandMode::JOINT_POSITION};
+    KUKA::FRI::EClientCommandMode client_command_mode{
+        KUKA::FRI::EClientCommandMode::JOINT_POSITION};
 #endif
-  int32_t port_id{30200};
-  const char *remote_host{nullptr};
-  int32_t rt_prio{80};
-  double joint_position_tau{0.04};
-  std::string command_guard_variant{"default"};
-  bool state_guard_external_torque_safety_check{true};
-  double state_guard_external_torque_limit{2.0};
-  double external_torque_tau{0.04};
-  double measured_torque_tau{0.04};
-  bool open_loop{true};
-};
+    int32_t port_id{30200};
+    const char *remote_host{nullptr};
+    int32_t rt_prio{80};
+    double joint_position_tau{0.04};
+    std::string command_guard_variant{"default"};
+    bool state_guard_external_torque_safety_check{true};
+    double state_guard_external_torque_limit{2.0};
+    double external_torque_tau{0.04};
+    double measured_torque_tau{0.04};
+    bool open_loop{true};
+  };
 
-struct EstimatedFTSensorParameters {
-  bool enabled{true};
-  std::uint16_t update_rate{100};
-  int32_t rt_prio{30};
-  std::string chain_root{"lbr_link_0"};
-  std::string chain_tip{"lbr_link_ee"};
-  double damping{0.2};
-  double force_x_th{2.0};
-  double force_y_th{2.0};
-  double force_z_th{2.0};
-  double torque_x_th{0.5};
-  double torque_y_th{0.5};
-  double torque_z_th{0.5};
-};
+  struct EstimatedFTSensorParameters {
+    bool enabled{true};
+    std::uint16_t update_rate{100};
+    int32_t rt_prio{30};
+    std::string chain_root{"lbr_link_0"};
+    std::string chain_tip{"lbr_link_ee"};
+    double damping{0.2};
+    double force_x_th{2.0};
+    double force_y_th{2.0};
+    double force_z_th{2.0};
+    double torque_x_th{0.5};
+    double torque_y_th{0.5};
+    double torque_z_th{0.5};
+  };
 
-class SystemInterface : public hardware_interface::SystemInterface {
+  struct CommandKeys {
+    lbr_fri_ros2::jnt_name_array_t joint_position, torque;
+    lbr_fri_ros2::cart_name_array_t wrench;
+
+    void populate_keys(const hardware_interface::HardwareInfo &info) {
+      for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+        auto joint_name = info.joints[i].name;
+        joint_position[i] = joint_name + "/" + hardware_interface::HW_IF_POSITION;
+        torque[i] = joint_name + "/" + hardware_interface::HW_IF_EFFORT;
+      }
+      wrench[0] = std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_X;
+      wrench[1] = std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_Y;
+      wrench[2] = std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_Z;
+      wrench[3] = std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_X;
+      wrench[4] = std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_Y;
+      wrench[5] = std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_Z;
+    }
+  };
+
+  struct StateKeys {
+#if FRI_CLIENT_VERSION_MAJOR == 1
+    lbr_fri_ros2::jnt_name_array_t commanded_joint_position;
+#endif
+    lbr_fri_ros2::jnt_name_array_t commanded_torque, ipo_joint_position, position, external_torque,
+        effort, velocity;
+    std::string sample_time, session_state, connection_quality, safety_state, operation_mode,
+        drive_state, client_command_mode, overlay_type, control_mode, time_stamp_sec,
+        time_stamp_nano_sec, tracking_performance;
+    lbr_fri_ros2::cart_name_array_t estimated_ft;
+
+    void populate_keys(const hardware_interface::HardwareInfo &info) {
+      for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+        auto joint_name = info.joints[i].name;
+#if FRI_CLIENT_VERSION_MAJOR == 1
+        commanded_joint_position[i] = joint_name + "/" + HW_IF_COMMANDED_JOINT_POSITION;
+#endif
+        commanded_torque[i] = joint_name + "/" + HW_IF_COMMANDED_TORQUE;
+        ipo_joint_position[i] = joint_name + "/" + HW_IF_IPO_JOINT_POSITION;
+        position[i] = joint_name + "/" + hardware_interface::HW_IF_POSITION;
+        external_torque[i] = joint_name + "/" + HW_IF_EXTERNAL_TORQUE;
+        effort[i] = joint_name + "/" + hardware_interface::HW_IF_EFFORT;
+        velocity[i] = joint_name + "/" + hardware_interface::HW_IF_VELOCITY;
+      }
+
+      sample_time = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TRACKING_PERFORMANCE;
+      session_state = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SESSION_STATE;
+      connection_quality = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONNECTION_QUALITY;
+      safety_state = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SAFETY_STATE;
+      operation_mode = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_OPERATION_MODE;
+      drive_state = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_DRIVE_STATE;
+      client_command_mode = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CLIENT_COMMAND_MODE;
+      overlay_type = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_OVERLAY_TYPE;
+      control_mode = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONTROL_MODE;
+      time_stamp_sec = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC;
+      time_stamp_nano_sec = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC;
+      tracking_performance = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TRACKING_PERFORMANCE;
+
+      estimated_ft[0] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_X;
+      estimated_ft[1] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Y;
+      estimated_ft[2] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Z;
+      estimated_ft[3] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_X;
+      estimated_ft[4] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Y;
+      estimated_ft[5] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Z;
+    }
+  };
+
 protected:
 #if FRI_CLIENT_VERSION_MAJOR == 1
   static constexpr uint8_t LBR_FRI_STATE_INTERFACE_SIZE = 7;
@@ -149,6 +217,10 @@ protected:
   lbr_fri_ros2::cart_array_t ft_;
   std::shared_ptr<lbr_fri_ros2::FTEstimatorImpl> ft_estimator_impl_ptr_;
   std::unique_ptr<lbr_fri_ros2::FTEstimator> ft_estimator_ptr_;
+
+  // keys for command / state interfaces
+  CommandKeys command_keys_;
+  StateKeys state_keys_;
 };
 } // namespace lbr_ros2_control
 #endif // LBR_ROS2_CONTROL__SYSTEM_INTERFACE_HPP_

--- a/lbr_ros2_control/src/system_interface.cpp
+++ b/lbr_ros2_control/src/system_interface.cpp
@@ -75,6 +75,11 @@ SystemInterface::on_init(const hardware_interface::HardwareComponentInterfacePar
                                                                     ft_parameters_.update_rate);
   }
 
+  // populate the keys
+  command_keys_.populate_keys(info_);
+  state_keys_.populate_keys(info_);
+
+  // perform verifications
   if (!verify_number_of_joints_()) {
     return controller_interface::CallbackReturn::ERROR;
   }
@@ -211,9 +216,9 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
   }
 
   // exit once robot exits COMMANDING_ACTIVE (for safety)
-  if (exit_commanding_active_(static_cast<KUKA::FRI::ESessionState>(get_state(
-                                  std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SESSION_STATE)),
-                              static_cast<KUKA::FRI::ESessionState>(lbr_state.session_state))) {
+  if (exit_commanding_active_(
+          static_cast<KUKA::FRI::ESessionState>(get_state(state_keys_.session_state)),
+          static_cast<KUKA::FRI::ESessionState>(lbr_state.session_state))) {
     RCLCPP_ERROR_STREAM(get_node()->get_logger(),
                         lbr_fri_ros2::ColorScheme::ERROR
                             << "LBR left COMMANDING_ACTIVE. Please re-run lbr_bringup"
@@ -226,41 +231,32 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
 
   // set the joint state interfaces
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
-    auto joint_name = info_.joints[i].name;
 #if FRI_CLIENT_VERSION_MAJOR == 1
-    set_state(joint_name + "/" + HW_IF_COMMANDED_JOINT_POSITION,
-              lbr_state.commanded_joint_position[i]);
+    set_state(state_keys_.commanded_joint_position[i], lbr_state.commanded_joint_position[i]);
 #endif
-    set_state(joint_name + "/" + HW_IF_COMMANDED_TORQUE, lbr_state.commanded_torque[i]);
-    set_state(joint_name + "/" + HW_IF_IPO_JOINT_POSITION, lbr_state.ipo_joint_position[i]);
-    set_state(joint_name + "/" + hardware_interface::HW_IF_POSITION,
-              lbr_state.measured_joint_position[i]);
-    set_state(joint_name + "/" + HW_IF_EXTERNAL_TORQUE, lbr_state.external_torque[i]);
-    set_state(joint_name + "/" + hardware_interface::HW_IF_EFFORT, lbr_state.measured_torque[i]);
-    set_state(joint_name + "/" + hardware_interface::HW_IF_VELOCITY, velocity_[i]);
+    set_state(state_keys_.commanded_torque[i], lbr_state.commanded_torque[i]);
+    set_state(state_keys_.ipo_joint_position[i], lbr_state.ipo_joint_position[i]);
+    set_state(state_keys_.position[i], lbr_state.measured_joint_position[i]);
+    set_state(state_keys_.external_torque[i], lbr_state.external_torque[i]);
+    set_state(state_keys_.effort[i], lbr_state.measured_torque[i]);
+    set_state(state_keys_.velocity[i], velocity_[i]);
   }
 
-  // state interfaces that require cast
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SESSION_STATE,
-            static_cast<double>(lbr_state.session_state));
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONNECTION_QUALITY,
-            static_cast<double>(lbr_state.connection_quality));
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SAFETY_STATE,
-            static_cast<double>(lbr_state.safety_state));
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_OPERATION_MODE,
-            static_cast<double>(lbr_state.safety_state));
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_DRIVE_STATE,
-            static_cast<double>(lbr_state.drive_state));
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CLIENT_COMMAND_MODE,
-            static_cast<double>(lbr_state.client_command_mode));
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_OVERLAY_TYPE,
-            static_cast<double>(lbr_state.overlay_type));
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONTROL_MODE,
-            static_cast<double>(lbr_state.control_mode));
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC,
-            static_cast<double>(lbr_state.time_stamp_sec));
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC,
-            static_cast<double>(lbr_state.time_stamp_nano_sec));
+  // state interfaces without
+  set_state(state_keys_.sample_time, lbr_state.sample_time);
+  set_state(state_keys_.tracking_performance, lbr_state.tracking_performance);
+
+  // state interfaces with cast
+  set_state(state_keys_.session_state, static_cast<double>(lbr_state.session_state));
+  set_state(state_keys_.connection_quality, static_cast<double>(lbr_state.connection_quality));
+  set_state(state_keys_.safety_state, static_cast<double>(lbr_state.safety_state));
+  set_state(state_keys_.operation_mode, static_cast<double>(lbr_state.operation_mode));
+  set_state(state_keys_.drive_state, static_cast<double>(lbr_state.drive_state));
+  set_state(state_keys_.client_command_mode, static_cast<double>(lbr_state.client_command_mode));
+  set_state(state_keys_.overlay_type, static_cast<double>(lbr_state.overlay_type));
+  set_state(state_keys_.control_mode, static_cast<double>(lbr_state.control_mode));
+  set_state(state_keys_.time_stamp_sec, static_cast<double>(lbr_state.time_stamp_sec));
+  set_state(state_keys_.time_stamp_nano_sec, static_cast<double>(lbr_state.time_stamp_nano_sec));
 
   // additional velocity state interface
   compute_velocity_();
@@ -273,20 +269,16 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
     ft_estimator_impl_ptr_->set_q(lbr_state.measured_joint_position);
     ft_estimator_impl_ptr_->set_tau_ext(lbr_state.external_torque);
     ft_estimator_impl_ptr_->get_f_ext_tf(ft_);
-    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_X, ft_[0]);
-    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Y, ft_[1]);
-    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Z, ft_[2]);
-    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_X, ft_[3]);
-    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Y, ft_[4]);
-    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Z, ft_[5]);
+    for (std::size_t i = 0; i < lbr_fri_ros2::CARTESIAN_DOF; ++i) {
+      set_state(state_keys_.estimated_ft[i], ft_[i]);
+    }
   }
   return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type SystemInterface::write(const rclcpp::Time & /*time*/,
                                                        const rclcpp::Duration & /*period*/) {
-  if (static_cast<KUKA::FRI::ESessionState>(
-          get_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SESSION_STATE)) !=
+  if (static_cast<KUKA::FRI::ESessionState>(get_state(state_keys_.session_state)) !=
       KUKA::FRI::COMMANDING_ACTIVE) {
     return hardware_interface::return_type::OK;
   }
@@ -294,17 +286,12 @@ hardware_interface::return_type SystemInterface::write(const rclcpp::Time & /*ti
   // populate command message
   lbr_fri_idl::msg::LBRCommand lbr_command;
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
-    auto joint_name = info_.joints[i].name;
-    lbr_command.joint_position[i] =
-        get_command(joint_name + "/" + hardware_interface::HW_IF_POSITION);
-    lbr_command.torque[i] = get_command(joint_name + "/" + hardware_interface::HW_IF_EFFORT);
+    lbr_command.joint_position[i] = get_command(command_keys_.joint_position[i]);
+    lbr_command.torque[i] = get_command(command_keys_.torque[i]);
   }
-  lbr_command.wrench[0] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_X);
-  lbr_command.wrench[1] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_Y);
-  lbr_command.wrench[2] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_Z);
-  lbr_command.wrench[3] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_X);
-  lbr_command.wrench[4] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_Y);
-  lbr_command.wrench[5] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_Z);
+  for (std::size_t i = 0; i < lbr_fri_ros2::CARTESIAN_DOF; ++i) {
+    lbr_command.wrench[i] = get_command(command_keys_.wrench[i]);
+  }
 
   async_client_ptr_->get_command_interface()->buffer_command_target(lbr_command);
   return hardware_interface::return_type::OK;
@@ -420,70 +407,43 @@ bool SystemInterface::parse_ft_parameters_() {
 
 void SystemInterface::nan_command_interfaces_() {
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
-    auto joint_name = info_.joints[i].name;
-    set_command(joint_name + "/" + hardware_interface::HW_IF_POSITION,
-                std::numeric_limits<double>::quiet_NaN());
-    set_command(joint_name + "/" + hardware_interface::HW_IF_EFFORT,
-                std::numeric_limits<double>::quiet_NaN());
+    set_command(command_keys_.joint_position[i], std::numeric_limits<double>::quiet_NaN());
+    set_command(command_keys_.torque[i], std::numeric_limits<double>::quiet_NaN());
   }
-  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_X,
-              std::numeric_limits<double>::quiet_NaN());
-  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_Y,
-              std::numeric_limits<double>::quiet_NaN());
-  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_Z,
-              std::numeric_limits<double>::quiet_NaN());
-  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_X,
-              std::numeric_limits<double>::quiet_NaN());
-  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_Y,
-              std::numeric_limits<double>::quiet_NaN());
-  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_Z,
-              std::numeric_limits<double>::quiet_NaN());
+  for (std::size_t i = 0; i < lbr_fri_ros2::CARTESIAN_DOF; ++i) {
+    set_command(command_keys_.wrench[i], std::numeric_limits<double>::quiet_NaN());
+  }
 }
 
 void SystemInterface::nan_state_interfaces_() {
   // joint state interfaces
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
-    auto joint_name = info_.joints[i].name;
-    set_state(joint_name + "/" + hardware_interface::HW_IF_POSITION,
-              std::numeric_limits<double>::quiet_NaN());
+    set_state(state_keys_.position[i], std::numeric_limits<double>::quiet_NaN());
 #if FRI_CLIENT_VERSION_MAJOR == 1
-    set_state(joint_name + "/" + HW_IF_COMMANDED_JOINT_POSITION,
-              std::numeric_limits<double>::quiet_NaN());
+    set_state(state_keys_.commanded_joint_position[i], std::numeric_limits<double>::quiet_NaN());
 #endif
-    set_state(joint_name + "/" + hardware_interface::HW_IF_EFFORT,
-              std::numeric_limits<double>::quiet_NaN());
-    set_state(joint_name + "/" + HW_IF_COMMANDED_TORQUE, std::numeric_limits<double>::quiet_NaN());
-    set_state(joint_name + "/" + HW_IF_EXTERNAL_TORQUE, std::numeric_limits<double>::quiet_NaN());
-    set_state(joint_name + "/" + HW_IF_IPO_JOINT_POSITION,
-              std::numeric_limits<double>::quiet_NaN());
+    set_state(state_keys_.effort[i], std::numeric_limits<double>::quiet_NaN());
+    set_state(state_keys_.commanded_torque[i], std::numeric_limits<double>::quiet_NaN());
+    set_state(state_keys_.external_torque[i], std::numeric_limits<double>::quiet_NaN());
+    set_state(state_keys_.ipo_joint_position[i], std::numeric_limits<double>::quiet_NaN());
+    set_state(state_keys_.velocity[i], std::numeric_limits<double>::quiet_NaN());
   }
 
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SAMPLE_TIME,
-            std::numeric_limits<double>::quiet_NaN());
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TRACKING_PERFORMANCE,
-            std::numeric_limits<double>::quiet_NaN());
+  // state interface without cast
+  set_state(state_keys_.sample_time, std::numeric_limits<double>::quiet_NaN());
+  set_state(state_keys_.tracking_performance, std::numeric_limits<double>::quiet_NaN());
 
-  // state interfaces that require cast
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SESSION_STATE,
-            std::numeric_limits<double>::quiet_NaN());
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONNECTION_QUALITY,
-            std::numeric_limits<double>::quiet_NaN());
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SAFETY_STATE,
-            std::numeric_limits<double>::quiet_NaN());
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_OPERATION_MODE,
-            std::numeric_limits<double>::quiet_NaN());
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_DRIVE_STATE,
-            std::numeric_limits<double>::quiet_NaN());
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CLIENT_COMMAND_MODE,
-            std::numeric_limits<double>::quiet_NaN());
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_OVERLAY_TYPE,
-            std::numeric_limits<double>::quiet_NaN());
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONTROL_MODE,
-            std::numeric_limits<double>::quiet_NaN());
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC,
-            std::numeric_limits<double>::quiet_NaN());
-  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC,
-            std::numeric_limits<double>::quiet_NaN());
+  // state interfaces with cast
+  set_state(state_keys_.session_state, std::numeric_limits<double>::quiet_NaN());
+  set_state(state_keys_.connection_quality, std::numeric_limits<double>::quiet_NaN());
+  set_state(state_keys_.safety_state, std::numeric_limits<double>::quiet_NaN());
+  set_state(state_keys_.operation_mode, std::numeric_limits<double>::quiet_NaN());
+  set_state(state_keys_.drive_state, std::numeric_limits<double>::quiet_NaN());
+  set_state(state_keys_.client_command_mode, std::numeric_limits<double>::quiet_NaN());
+  set_state(state_keys_.overlay_type, std::numeric_limits<double>::quiet_NaN());
+  set_state(state_keys_.control_mode, std::numeric_limits<double>::quiet_NaN());
+  set_state(state_keys_.time_stamp_sec, std::numeric_limits<double>::quiet_NaN());
+  set_state(state_keys_.time_stamp_nano_sec, std::numeric_limits<double>::quiet_NaN());
 
   // additional velocity state interface
   velocity_.fill(std::numeric_limits<double>::quiet_NaN());
@@ -718,13 +678,10 @@ void SystemInterface::nan_last_states_() {
 
 void SystemInterface::update_last_states_() {
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
-    last_measured_joint_position_[i] =
-        get_state(info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION);
+    last_measured_joint_position_[i] = get_state(state_keys_.position[i]);
   }
-  last_time_stamp_sec_ =
-      get_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC);
-  last_time_stamp_nano_sec_ =
-      get_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC);
+  last_time_stamp_sec_ = get_state(state_keys_.time_stamp_sec);
+  last_time_stamp_nano_sec_ = get_state(state_keys_.time_stamp_nano_sec);
 }
 
 void SystemInterface::compute_velocity_() {
@@ -733,9 +690,8 @@ void SystemInterface::compute_velocity_() {
     return;
   }
 
-  auto time_stamp_sec = get_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC);
-  auto time_stamp_nano_sec =
-      get_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC);
+  auto time_stamp_sec = get_state(state_keys_.time_stamp_sec);
+  auto time_stamp_nano_sec = get_state(state_keys_.time_stamp_nano_sec);
 
   // state wasn't updated
   if (last_time_stamp_sec_ == time_stamp_sec && last_time_stamp_nano_sec_ == time_stamp_nano_sec) {
@@ -745,9 +701,7 @@ void SystemInterface::compute_velocity_() {
   double dt = time_stamps_to_sec_(time_stamp_sec, time_stamp_nano_sec) -
               time_stamps_to_sec_(last_time_stamp_sec_, last_time_stamp_nano_sec_);
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
-    velocity_[i] = (get_state(info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION) -
-                    last_measured_joint_position_[i]) /
-                   dt;
+    velocity_[i] = (get_state(state_keys_.position[i]) - last_measured_joint_position_[i]) / dt;
   }
 }
 

--- a/lbr_ros2_control/src/system_interface.cpp
+++ b/lbr_ros2_control/src/system_interface.cpp
@@ -56,10 +56,6 @@ SystemInterface::on_init(const hardware_interface::HardwareComponentInterfacePar
     return controller_interface::CallbackReturn::ERROR;
   }
 
-  nan_command_interfaces_();
-  nan_state_interfaces_();
-  nan_last_hw_states_();
-
   // setup force-torque estimator
   if (!parse_ft_parameters_()) {
     return controller_interface::CallbackReturn::ERROR;
@@ -102,92 +98,6 @@ SystemInterface::on_init(const hardware_interface::HardwareComponentInterfacePar
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
-std::vector<hardware_interface::StateInterface> SystemInterface::export_state_interfaces() {
-  std::vector<hardware_interface::StateInterface> state_interfaces;
-  // state interfaces of type double
-  for (std::size_t i = 0; i < info_.joints.size(); ++i) {
-    state_interfaces.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_POSITION,
-                                  &hw_lbr_state_.measured_joint_position[i]);
-
-#if FRI_CLIENT_VERSION_MAJOR == 1
-    state_interfaces.emplace_back(info_.joints[i].name, HW_IF_COMMANDED_JOINT_POSITION,
-                                  &hw_lbr_state_.commanded_joint_position[i]);
-#endif
-
-    state_interfaces.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_EFFORT,
-                                  &hw_lbr_state_.measured_torque[i]);
-
-    state_interfaces.emplace_back(info_.joints[i].name, HW_IF_COMMANDED_TORQUE,
-                                  &hw_lbr_state_.commanded_torque[i]);
-
-    state_interfaces.emplace_back(info_.joints[i].name, HW_IF_EXTERNAL_TORQUE,
-                                  &hw_lbr_state_.external_torque[i]);
-
-    state_interfaces.emplace_back(info_.joints[i].name, HW_IF_IPO_JOINT_POSITION,
-                                  &hw_lbr_state_.ipo_joint_position[i]);
-
-    // additional velocity state interface
-    state_interfaces.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_VELOCITY,
-                                  &hw_velocity_[i]);
-  }
-
-  const auto &auxiliary_sensor = info_.sensors[0];
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_SAMPLE_TIME,
-                                &hw_lbr_state_.sample_time);
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_TRACKING_PERFORMANCE,
-                                &hw_lbr_state_.tracking_performance);
-
-  // state interfaces that require cast
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_SESSION_STATE, &hw_session_state_);
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_CONNECTION_QUALITY,
-                                &hw_connection_quality_);
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_SAFETY_STATE, &hw_safety_state_);
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_OPERATION_MODE, &hw_operation_mode_);
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_DRIVE_STATE, &hw_drive_state_);
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_CLIENT_COMMAND_MODE,
-                                &hw_client_command_mode_);
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_OVERLAY_TYPE, &hw_overlay_type_);
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_CONTROL_MODE, &hw_control_mode_);
-
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_TIME_STAMP_SEC, &hw_time_stamp_sec_);
-  state_interfaces.emplace_back(auxiliary_sensor.name, HW_IF_TIME_STAMP_NANO_SEC,
-                                &hw_time_stamp_nano_sec_);
-
-  // additional force-torque state interface (if enabled)
-  if (ft_parameters_.enabled) {
-    const auto &estimated_ft_sensor = info_.sensors[1];
-    state_interfaces.emplace_back(estimated_ft_sensor.name, HW_IF_FORCE_X, &hw_ft_[0]);
-    state_interfaces.emplace_back(estimated_ft_sensor.name, HW_IF_FORCE_Y, &hw_ft_[1]);
-    state_interfaces.emplace_back(estimated_ft_sensor.name, HW_IF_FORCE_Z, &hw_ft_[2]);
-    state_interfaces.emplace_back(estimated_ft_sensor.name, HW_IF_TORQUE_X, &hw_ft_[3]);
-    state_interfaces.emplace_back(estimated_ft_sensor.name, HW_IF_TORQUE_Y, &hw_ft_[4]);
-    state_interfaces.emplace_back(estimated_ft_sensor.name, HW_IF_TORQUE_Z, &hw_ft_[5]);
-  }
-
-  return state_interfaces;
-}
-
-std::vector<hardware_interface::CommandInterface> SystemInterface::export_command_interfaces() {
-  std::vector<hardware_interface::CommandInterface> command_interfaces;
-  for (std::size_t i = 0; i < info_.joints.size(); ++i) {
-    command_interfaces.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_POSITION,
-                                    &hw_lbr_command_.joint_position[i]);
-
-    command_interfaces.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_EFFORT,
-                                    &hw_lbr_command_.torque[i]);
-  }
-
-  // Cartesian impedance control command interfaces
-  const auto &wrench = info_.gpios[0];
-  command_interfaces.emplace_back(wrench.name, HW_IF_FORCE_X, &hw_lbr_command_.wrench[0]);
-  command_interfaces.emplace_back(wrench.name, HW_IF_FORCE_Y, &hw_lbr_command_.wrench[1]);
-  command_interfaces.emplace_back(wrench.name, HW_IF_FORCE_Z, &hw_lbr_command_.wrench[2]);
-  command_interfaces.emplace_back(wrench.name, HW_IF_TORQUE_X, &hw_lbr_command_.wrench[3]);
-  command_interfaces.emplace_back(wrench.name, HW_IF_TORQUE_Y, &hw_lbr_command_.wrench[4]);
-  command_interfaces.emplace_back(wrench.name, HW_IF_TORQUE_Z, &hw_lbr_command_.wrench[5]);
-  return command_interfaces;
-}
-
 hardware_interface::return_type
 SystemInterface::prepare_command_mode_switch(const std::vector<std::string> & /*start_interfaces*/,
                                              const std::vector<std::string> & /*stop_interfaces*/) {
@@ -209,6 +119,13 @@ SystemInterface::on_configure(const rclcpp_lifecycle::State &) {
 }
 
 controller_interface::CallbackReturn SystemInterface::on_activate(const rclcpp_lifecycle::State &) {
+  // nan all command and state interfaces (this might be removed in the future with ros2_control
+  // handling them now)
+  nan_command_interfaces_();
+  nan_state_interfaces_();
+  nan_last_states_();
+
+  // run the FRI app
   app_ptr_->run_async(parameters_.rt_prio);
   int attempt = 0;
   while (!async_client_ptr_->get_state_interface()->is_initialized()) {
@@ -283,19 +200,20 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
     return hardware_interface::return_type::OK;
   }
 
-  hw_lbr_state_ = async_client_ptr_->get_state_interface()->get_state();
+  auto lbr_state = async_client_ptr_->get_state_interface()->get_state();
 
-  if (period.seconds() - hw_lbr_state_.sample_time * 0.2 > hw_lbr_state_.sample_time) {
+  if (period.seconds() - lbr_state.sample_time * 0.2 > lbr_state.sample_time) {
     RCLCPP_WARN_STREAM(get_node()->get_logger(),
                        lbr_fri_ros2::ColorScheme::WARNING
                            << "Increase update_rate parameter for controller_manager to "
-                           << std::to_string(static_cast<int>(1. / hw_lbr_state_.sample_time))
+                           << std::to_string(static_cast<int>(1. / lbr_state.sample_time))
                            << " Hz or more" << lbr_fri_ros2::ColorScheme::ENDC);
   }
 
   // exit once robot exits COMMANDING_ACTIVE (for safety)
-  if (exit_commanding_active_(static_cast<KUKA::FRI::ESessionState>(hw_session_state_),
-                              static_cast<KUKA::FRI::ESessionState>(hw_lbr_state_.session_state))) {
+  if (exit_commanding_active_(static_cast<KUKA::FRI::ESessionState>(get_state(
+                                  std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SESSION_STATE)),
+                              static_cast<KUKA::FRI::ESessionState>(lbr_state.session_state))) {
     RCLCPP_ERROR_STREAM(get_node()->get_logger(),
                         lbr_fri_ros2::ColorScheme::ERROR
                             << "LBR left COMMANDING_ACTIVE. Please re-run lbr_bringup"
@@ -306,39 +224,89 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
     return hardware_interface::return_type::ERROR;
   }
 
+  // set the joint state interfaces
+  for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+    auto joint_name = info_.joints[i].name;
+#if FRI_CLIENT_VERSION_MAJOR == 1
+    set_state(joint_name + "/" + HW_IF_COMMANDED_JOINT_POSITION,
+              lbr_state.commanded_joint_position[i]);
+#endif
+    set_state(joint_name + "/" + HW_IF_COMMANDED_TORQUE, lbr_state.commanded_torque[i]);
+    set_state(joint_name + "/" + HW_IF_IPO_JOINT_POSITION, lbr_state.ipo_joint_position[i]);
+    set_state(joint_name + "/" + hardware_interface::HW_IF_POSITION,
+              lbr_state.measured_joint_position[i]);
+    set_state(joint_name + "/" + HW_IF_EXTERNAL_TORQUE, lbr_state.external_torque[i]);
+    set_state(joint_name + "/" + hardware_interface::HW_IF_EFFORT, lbr_state.measured_torque[i]);
+    set_state(joint_name + "/" + hardware_interface::HW_IF_VELOCITY, velocity_[i]);
+  }
+
   // state interfaces that require cast
-  hw_session_state_ = static_cast<double>(hw_lbr_state_.session_state);
-  hw_connection_quality_ = static_cast<double>(hw_lbr_state_.connection_quality);
-  hw_safety_state_ = static_cast<double>(hw_lbr_state_.safety_state);
-  hw_operation_mode_ = static_cast<double>(hw_lbr_state_.operation_mode);
-  hw_drive_state_ = static_cast<double>(hw_lbr_state_.drive_state);
-  hw_client_command_mode_ = static_cast<double>(hw_lbr_state_.client_command_mode);
-  hw_overlay_type_ = static_cast<double>(hw_lbr_state_.overlay_type);
-  hw_control_mode_ = static_cast<double>(hw_lbr_state_.control_mode);
-  hw_time_stamp_sec_ = static_cast<double>(hw_lbr_state_.time_stamp_sec);
-  hw_time_stamp_nano_sec_ = static_cast<double>(hw_lbr_state_.time_stamp_nano_sec);
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SESSION_STATE,
+            static_cast<double>(lbr_state.session_state));
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONNECTION_QUALITY,
+            static_cast<double>(lbr_state.connection_quality));
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SAFETY_STATE,
+            static_cast<double>(lbr_state.safety_state));
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_OPERATION_MODE,
+            static_cast<double>(lbr_state.safety_state));
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_DRIVE_STATE,
+            static_cast<double>(lbr_state.drive_state));
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CLIENT_COMMAND_MODE,
+            static_cast<double>(lbr_state.client_command_mode));
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_OVERLAY_TYPE,
+            static_cast<double>(lbr_state.overlay_type));
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONTROL_MODE,
+            static_cast<double>(lbr_state.control_mode));
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC,
+            static_cast<double>(lbr_state.time_stamp_sec));
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC,
+            static_cast<double>(lbr_state.time_stamp_nano_sec));
 
   // additional velocity state interface
-  compute_hw_velocity_();
-  update_last_hw_states_();
+  compute_velocity_();
+  update_last_states_();
 
   // additional force-torque state interface
   if (ft_parameters_.enabled) {
     // note that (if enabled) the computation is performed asynchronously to not block the main
     // thread
-    ft_estimator_impl_ptr_->set_q(hw_lbr_state_.measured_joint_position);
-    ft_estimator_impl_ptr_->set_tau_ext(hw_lbr_state_.external_torque);
-    ft_estimator_impl_ptr_->get_f_ext_tf(hw_ft_);
+    ft_estimator_impl_ptr_->set_q(lbr_state.measured_joint_position);
+    ft_estimator_impl_ptr_->set_tau_ext(lbr_state.external_torque);
+    ft_estimator_impl_ptr_->get_f_ext_tf(ft_);
+    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_X, ft_[0]);
+    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Y, ft_[1]);
+    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Z, ft_[2]);
+    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_X, ft_[3]);
+    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Y, ft_[4]);
+    set_state(std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Z, ft_[5]);
   }
   return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type SystemInterface::write(const rclcpp::Time & /*time*/,
                                                        const rclcpp::Duration & /*period*/) {
-  if (hw_session_state_ != KUKA::FRI::COMMANDING_ACTIVE) {
+  if (static_cast<KUKA::FRI::ESessionState>(
+          get_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SESSION_STATE)) !=
+      KUKA::FRI::COMMANDING_ACTIVE) {
     return hardware_interface::return_type::OK;
   }
-  async_client_ptr_->get_command_interface()->buffer_command_target(hw_lbr_command_);
+
+  // populate command message
+  lbr_fri_idl::msg::LBRCommand lbr_command;
+  for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+    auto joint_name = info_.joints[i].name;
+    lbr_command.joint_position[i] =
+        get_command(joint_name + "/" + hardware_interface::HW_IF_POSITION);
+    lbr_command.torque[i] = get_command(joint_name + "/" + hardware_interface::HW_IF_EFFORT);
+  }
+  lbr_command.wrench[0] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_X);
+  lbr_command.wrench[1] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_Y);
+  lbr_command.wrench[2] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_Z);
+  lbr_command.wrench[3] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_X);
+  lbr_command.wrench[4] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_Y);
+  lbr_command.wrench[5] = get_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_Z);
+
+  async_client_ptr_->get_command_interface()->buffer_command_target(lbr_command);
   return hardware_interface::return_type::OK;
 }
 
@@ -451,41 +419,77 @@ bool SystemInterface::parse_ft_parameters_() {
 }
 
 void SystemInterface::nan_command_interfaces_() {
-  hw_lbr_command_.joint_position.fill(std::numeric_limits<double>::quiet_NaN());
-  hw_lbr_command_.torque.fill(std::numeric_limits<double>::quiet_NaN());
-  hw_lbr_command_.wrench.fill(std::numeric_limits<double>::quiet_NaN());
+  for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+    auto joint_name = info_.joints[i].name;
+    set_command(joint_name + "/" + hardware_interface::HW_IF_POSITION,
+                std::numeric_limits<double>::quiet_NaN());
+    set_command(joint_name + "/" + hardware_interface::HW_IF_EFFORT,
+                std::numeric_limits<double>::quiet_NaN());
+  }
+  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_X,
+              std::numeric_limits<double>::quiet_NaN());
+  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_Y,
+              std::numeric_limits<double>::quiet_NaN());
+  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_FORCE_Z,
+              std::numeric_limits<double>::quiet_NaN());
+  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_X,
+              std::numeric_limits<double>::quiet_NaN());
+  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_Y,
+              std::numeric_limits<double>::quiet_NaN());
+  set_command(std::string(HW_IF_WRENCH_PREFIX) + "/" + HW_IF_TORQUE_Z,
+              std::numeric_limits<double>::quiet_NaN());
 }
 
 void SystemInterface::nan_state_interfaces_() {
-  // state interfaces of type double
-  hw_lbr_state_.measured_joint_position.fill(std::numeric_limits<double>::quiet_NaN());
+  // joint state interfaces
+  for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+    auto joint_name = info_.joints[i].name;
+    set_state(joint_name + "/" + hardware_interface::HW_IF_POSITION,
+              std::numeric_limits<double>::quiet_NaN());
 #if FRI_CLIENT_VERSION_MAJOR == 1
-  hw_lbr_state_.commanded_joint_position.fill(std::numeric_limits<double>::quiet_NaN());
+    set_state(joint_name + "/" + HW_IF_COMMANDED_JOINT_POSITION,
+              std::numeric_limits<double>::quiet_NaN());
 #endif
-  hw_lbr_state_.measured_torque.fill(std::numeric_limits<double>::quiet_NaN());
-  hw_lbr_state_.commanded_torque.fill(std::numeric_limits<double>::quiet_NaN());
-  hw_lbr_state_.external_torque.fill(std::numeric_limits<double>::quiet_NaN());
-  hw_lbr_state_.ipo_joint_position.fill(std::numeric_limits<double>::quiet_NaN());
-  hw_lbr_state_.sample_time = std::numeric_limits<double>::quiet_NaN();
-  hw_lbr_state_.tracking_performance = std::numeric_limits<double>::quiet_NaN();
+    set_state(joint_name + "/" + hardware_interface::HW_IF_EFFORT,
+              std::numeric_limits<double>::quiet_NaN());
+    set_state(joint_name + "/" + HW_IF_COMMANDED_TORQUE, std::numeric_limits<double>::quiet_NaN());
+    set_state(joint_name + "/" + HW_IF_EXTERNAL_TORQUE, std::numeric_limits<double>::quiet_NaN());
+    set_state(joint_name + "/" + HW_IF_IPO_JOINT_POSITION,
+              std::numeric_limits<double>::quiet_NaN());
+  }
+
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SAMPLE_TIME,
+            std::numeric_limits<double>::quiet_NaN());
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TRACKING_PERFORMANCE,
+            std::numeric_limits<double>::quiet_NaN());
 
   // state interfaces that require cast
-  hw_session_state_ = std::numeric_limits<double>::quiet_NaN();
-  hw_connection_quality_ = std::numeric_limits<double>::quiet_NaN();
-  hw_safety_state_ = std::numeric_limits<double>::quiet_NaN();
-  hw_operation_mode_ = std::numeric_limits<double>::quiet_NaN();
-  hw_drive_state_ = std::numeric_limits<double>::quiet_NaN();
-  hw_client_command_mode_ = std::numeric_limits<double>::quiet_NaN();
-  hw_overlay_type_ = std::numeric_limits<double>::quiet_NaN();
-  hw_control_mode_ = std::numeric_limits<double>::quiet_NaN();
-  hw_time_stamp_sec_ = std::numeric_limits<double>::quiet_NaN();
-  hw_time_stamp_nano_sec_ = std::numeric_limits<double>::quiet_NaN();
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SESSION_STATE,
+            std::numeric_limits<double>::quiet_NaN());
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONNECTION_QUALITY,
+            std::numeric_limits<double>::quiet_NaN());
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_SAFETY_STATE,
+            std::numeric_limits<double>::quiet_NaN());
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_OPERATION_MODE,
+            std::numeric_limits<double>::quiet_NaN());
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_DRIVE_STATE,
+            std::numeric_limits<double>::quiet_NaN());
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CLIENT_COMMAND_MODE,
+            std::numeric_limits<double>::quiet_NaN());
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_OVERLAY_TYPE,
+            std::numeric_limits<double>::quiet_NaN());
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_CONTROL_MODE,
+            std::numeric_limits<double>::quiet_NaN());
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC,
+            std::numeric_limits<double>::quiet_NaN());
+  set_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC,
+            std::numeric_limits<double>::quiet_NaN());
 
   // additional velocity state interface
-  hw_velocity_.fill(std::numeric_limits<double>::quiet_NaN());
+  velocity_.fill(std::numeric_limits<double>::quiet_NaN());
 
   // additional force-torque state interface
-  hw_ft_.fill(std::numeric_limits<double>::quiet_NaN());
+  ft_.fill(std::numeric_limits<double>::quiet_NaN());
 }
 
 bool SystemInterface::verify_number_of_joints_() {
@@ -679,13 +683,13 @@ bool SystemInterface::verify_gpios_() {
                                                       << lbr_fri_ros2::ColorScheme::ENDC);
     return false;
   }
-  if (info_.gpios[0].command_interfaces.size() != hw_lbr_command_.wrench.size()) {
+  if (info_.gpios[0].command_interfaces.size() != lbr_fri_ros2::CARTESIAN_DOF) {
     RCLCPP_ERROR_STREAM(get_node()->get_logger(),
                         lbr_fri_ros2::ColorScheme::ERROR
                             << "GPIO '" << info_.gpios[0].name.c_str()
                             << "' received invalid number of command interfaces. Received '"
                             << info_.gpios[0].command_interfaces.size() << "', expected '"
-                            << hw_lbr_command_.wrench.size() << "'"
+                            << lbr_fri_ros2::CARTESIAN_DOF << "'"
                             << lbr_fri_ros2::ColorScheme::ENDC);
     return false;
   }
@@ -706,37 +710,45 @@ double SystemInterface::time_stamps_to_sec_(const double &sec, const double &nan
   return sec + nano_sec / 1.e9;
 }
 
-void SystemInterface::nan_last_hw_states_() {
-  last_hw_measured_joint_position_.fill(std::numeric_limits<double>::quiet_NaN());
-  last_hw_time_stamp_sec_ = std::numeric_limits<double>::quiet_NaN();
-  last_hw_time_stamp_nano_sec_ = std::numeric_limits<double>::quiet_NaN();
+void SystemInterface::nan_last_states_() {
+  last_measured_joint_position_.fill(std::numeric_limits<double>::quiet_NaN());
+  last_time_stamp_sec_ = std::numeric_limits<double>::quiet_NaN();
+  last_time_stamp_nano_sec_ = std::numeric_limits<double>::quiet_NaN();
 }
 
-void SystemInterface::update_last_hw_states_() {
-  last_hw_measured_joint_position_ = hw_lbr_state_.measured_joint_position;
-  last_hw_time_stamp_sec_ = hw_time_stamp_sec_;
-  last_hw_time_stamp_nano_sec_ = hw_time_stamp_nano_sec_;
+void SystemInterface::update_last_states_() {
+  for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+    last_measured_joint_position_[i] =
+        get_state(info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION);
+  }
+  last_time_stamp_sec_ =
+      get_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC);
+  last_time_stamp_nano_sec_ =
+      get_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC);
 }
 
-void SystemInterface::compute_hw_velocity_() {
+void SystemInterface::compute_velocity_() {
   // state uninitialized
-  if (std::isnan(last_hw_time_stamp_nano_sec_) || std::isnan(last_hw_measured_joint_position_[0])) {
+  if (std::isnan(last_time_stamp_nano_sec_) || std::isnan(last_measured_joint_position_[0])) {
     return;
   }
+
+  auto time_stamp_sec = get_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC);
+  auto time_stamp_nano_sec =
+      get_state(std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC);
 
   // state wasn't updated
-  if (last_hw_time_stamp_sec_ == hw_time_stamp_sec_ &&
-      last_hw_time_stamp_nano_sec_ == hw_time_stamp_nano_sec_) {
+  if (last_time_stamp_sec_ == time_stamp_sec && last_time_stamp_nano_sec_ == time_stamp_nano_sec) {
     return;
   }
 
-  double dt = time_stamps_to_sec_(hw_time_stamp_sec_, hw_time_stamp_nano_sec_) -
-              time_stamps_to_sec_(last_hw_time_stamp_sec_, last_hw_time_stamp_nano_sec_);
-  std::size_t i = 0;
-  std::for_each(hw_velocity_.begin(), hw_velocity_.end(), [&](double &v) {
-    v = (hw_lbr_state_.measured_joint_position[i] - last_hw_measured_joint_position_[i]) / dt;
-    ++i;
-  });
+  double dt = time_stamps_to_sec_(time_stamp_sec, time_stamp_nano_sec) -
+              time_stamps_to_sec_(last_time_stamp_sec_, last_time_stamp_nano_sec_);
+  for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+    velocity_[i] = (get_state(info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION) -
+                    last_measured_joint_position_[i]) /
+                   dt;
+  }
 }
 
 } // namespace lbr_ros2_control

--- a/lbr_ros2_control/src/system_interface.cpp
+++ b/lbr_ros2_control/src/system_interface.cpp
@@ -205,20 +205,20 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
     return hardware_interface::return_type::OK;
   }
 
-  auto lbr_state = async_client_ptr_->get_state_interface()->get_state();
+  lbr_state_ = async_client_ptr_->get_state_interface()->get_state();
 
-  if (period.seconds() - lbr_state.sample_time * 0.2 > lbr_state.sample_time) {
+  if (period.seconds() - lbr_state_.sample_time * 0.2 > lbr_state_.sample_time) {
     RCLCPP_WARN_STREAM(get_node()->get_logger(),
                        lbr_fri_ros2::ColorScheme::WARNING
                            << "Increase update_rate parameter for controller_manager to "
-                           << std::to_string(static_cast<int>(1. / lbr_state.sample_time))
+                           << std::to_string(static_cast<int>(1. / lbr_state_.sample_time))
                            << " Hz or more" << lbr_fri_ros2::ColorScheme::ENDC);
   }
 
   // exit once robot exits COMMANDING_ACTIVE (for safety)
   if (exit_commanding_active_(
           static_cast<KUKA::FRI::ESessionState>(get_state(state_keys_.session_state)),
-          static_cast<KUKA::FRI::ESessionState>(lbr_state.session_state))) {
+          static_cast<KUKA::FRI::ESessionState>(lbr_state_.session_state))) {
     RCLCPP_ERROR_STREAM(get_node()->get_logger(),
                         lbr_fri_ros2::ColorScheme::ERROR
                             << "LBR left COMMANDING_ACTIVE. Please re-run lbr_bringup"
@@ -232,31 +232,31 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
   // set the joint state interfaces
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
 #if FRI_CLIENT_VERSION_MAJOR == 1
-    set_state(state_keys_.commanded_joint_position[i], lbr_state.commanded_joint_position[i]);
+    set_state(state_keys_.commanded_joint_position[i], lbr_state_.commanded_joint_position[i]);
 #endif
-    set_state(state_keys_.commanded_torque[i], lbr_state.commanded_torque[i]);
-    set_state(state_keys_.ipo_joint_position[i], lbr_state.ipo_joint_position[i]);
-    set_state(state_keys_.position[i], lbr_state.measured_joint_position[i]);
-    set_state(state_keys_.external_torque[i], lbr_state.external_torque[i]);
-    set_state(state_keys_.effort[i], lbr_state.measured_torque[i]);
+    set_state(state_keys_.commanded_torque[i], lbr_state_.commanded_torque[i]);
+    set_state(state_keys_.ipo_joint_position[i], lbr_state_.ipo_joint_position[i]);
+    set_state(state_keys_.position[i], lbr_state_.measured_joint_position[i]);
+    set_state(state_keys_.external_torque[i], lbr_state_.external_torque[i]);
+    set_state(state_keys_.effort[i], lbr_state_.measured_torque[i]);
     set_state(state_keys_.velocity[i], velocity_[i]);
   }
 
   // state interfaces without
-  set_state(state_keys_.sample_time, lbr_state.sample_time);
-  set_state(state_keys_.tracking_performance, lbr_state.tracking_performance);
+  set_state(state_keys_.sample_time, lbr_state_.sample_time);
+  set_state(state_keys_.tracking_performance, lbr_state_.tracking_performance);
 
   // state interfaces with cast
-  set_state(state_keys_.session_state, static_cast<double>(lbr_state.session_state));
-  set_state(state_keys_.connection_quality, static_cast<double>(lbr_state.connection_quality));
-  set_state(state_keys_.safety_state, static_cast<double>(lbr_state.safety_state));
-  set_state(state_keys_.operation_mode, static_cast<double>(lbr_state.operation_mode));
-  set_state(state_keys_.drive_state, static_cast<double>(lbr_state.drive_state));
-  set_state(state_keys_.client_command_mode, static_cast<double>(lbr_state.client_command_mode));
-  set_state(state_keys_.overlay_type, static_cast<double>(lbr_state.overlay_type));
-  set_state(state_keys_.control_mode, static_cast<double>(lbr_state.control_mode));
-  set_state(state_keys_.time_stamp_sec, static_cast<double>(lbr_state.time_stamp_sec));
-  set_state(state_keys_.time_stamp_nano_sec, static_cast<double>(lbr_state.time_stamp_nano_sec));
+  set_state(state_keys_.session_state, static_cast<double>(lbr_state_.session_state));
+  set_state(state_keys_.connection_quality, static_cast<double>(lbr_state_.connection_quality));
+  set_state(state_keys_.safety_state, static_cast<double>(lbr_state_.safety_state));
+  set_state(state_keys_.operation_mode, static_cast<double>(lbr_state_.operation_mode));
+  set_state(state_keys_.drive_state, static_cast<double>(lbr_state_.drive_state));
+  set_state(state_keys_.client_command_mode, static_cast<double>(lbr_state_.client_command_mode));
+  set_state(state_keys_.overlay_type, static_cast<double>(lbr_state_.overlay_type));
+  set_state(state_keys_.control_mode, static_cast<double>(lbr_state_.control_mode));
+  set_state(state_keys_.time_stamp_sec, static_cast<double>(lbr_state_.time_stamp_sec));
+  set_state(state_keys_.time_stamp_nano_sec, static_cast<double>(lbr_state_.time_stamp_nano_sec));
 
   // additional velocity state interface
   compute_velocity_();
@@ -266,8 +266,8 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
   if (ft_parameters_.enabled) {
     // note that (if enabled) the computation is performed asynchronously to not block the main
     // thread
-    ft_estimator_impl_ptr_->set_q(lbr_state.measured_joint_position);
-    ft_estimator_impl_ptr_->set_tau_ext(lbr_state.external_torque);
+    ft_estimator_impl_ptr_->set_q(lbr_state_.measured_joint_position);
+    ft_estimator_impl_ptr_->set_tau_ext(lbr_state_.external_torque);
     ft_estimator_impl_ptr_->get_f_ext_tf(ft_);
     for (std::size_t i = 0; i < lbr_fri_ros2::CARTESIAN_DOF; ++i) {
       set_state(state_keys_.estimated_ft[i], ft_[i]);
@@ -284,16 +284,15 @@ hardware_interface::return_type SystemInterface::write(const rclcpp::Time & /*ti
   }
 
   // populate command message
-  lbr_fri_idl::msg::LBRCommand lbr_command;
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
-    lbr_command.joint_position[i] = get_command(command_keys_.joint_position[i]);
-    lbr_command.torque[i] = get_command(command_keys_.torque[i]);
+    lbr_command_.joint_position[i] = get_command(command_keys_.joint_position[i]);
+    lbr_command_.torque[i] = get_command(command_keys_.torque[i]);
   }
   for (std::size_t i = 0; i < lbr_fri_ros2::CARTESIAN_DOF; ++i) {
-    lbr_command.wrench[i] = get_command(command_keys_.wrench[i]);
+    lbr_command_.wrench[i] = get_command(command_keys_.wrench[i]);
   }
 
-  async_client_ptr_->get_command_interface()->buffer_command_target(lbr_command);
+  async_client_ptr_->get_command_interface()->buffer_command_target(lbr_command_);
   return hardware_interface::return_type::OK;
 }
 


### PR DESCRIPTION
Refer to `ros2_control` `Humble` -> `Jazzy` migration notes: https://control.ros.org/jazzy/doc/ros2_control/doc/migration.html#migration-of-command-stateinterfaces

Check with `ros2_control` upstream: https://github.com/ros-controls/ros2_control/issues/2816