### PR TITLE
Removes FT estimation from system interface

### DIFF
--- a/lbr_demos/lbr_demos_advanced_cpp/src/lbr_base_position_command_node.hpp
+++ b/lbr_demos/lbr_demos_advanced_cpp/src/lbr_base_position_command_node.hpp
@@ -25,7 +25,7 @@ public:
         "command/lbr_joint_position_command", 1);
 
     lbr_state_sub_ = create_subscription<lbr_fri_idl::msg::LBRState>(
-        "state", 1,
+        "lbr_state", 1,
         std::bind(&LBRBasePositionCommandNode::on_lbr_state_, this, std::placeholders::_1));
   }
 

--- a/lbr_demos/lbr_demos_advanced_py/lbr_demos_advanced_py/lbr_base_position_command_node.py
+++ b/lbr_demos/lbr_demos_advanced_py/lbr_demos_advanced_py/lbr_base_position_command_node.py
@@ -30,7 +30,7 @@ class LBRBasePositionCommandNode(Node):
 
         # publishers and subscribers
         self._lbr_state_sub = self.create_subscription(
-            LBRState, "state", self._on_lbr_state, 1
+            LBRState, "lbr_state", self._on_lbr_state, 1
         )
         self._lbr_joint_position_command_pub = self.create_publisher(
             LBRJointPositionCommand,

--- a/lbr_demos/lbr_demos_cpp/src/joint_sine_overlay.cpp
+++ b/lbr_demos/lbr_demos_cpp/src/joint_sine_overlay.cpp
@@ -26,7 +26,7 @@ public:
 
     // create subscription to state
     lbr_state_sub_ = node_->create_subscription<lbr_fri_idl::msg::LBRState>(
-        "state", 1, std::bind(&JointSineOverlay::on_lbr_state_, this, std::placeholders::_1));
+        "lbr_state", 1, std::bind(&JointSineOverlay::on_lbr_state_, this, std::placeholders::_1));
 
     // get control rate from controller_manager
     auto update_rate =

--- a/lbr_demos/lbr_demos_cpp/src/torque_sine_overlay.cpp
+++ b/lbr_demos/lbr_demos_cpp/src/torque_sine_overlay.cpp
@@ -25,7 +25,7 @@ public:
 
     // create subscription to state
     lbr_state_sub_ = node_->create_subscription<lbr_fri_idl::msg::LBRState>(
-        "state", 1, std::bind(&TorqueSineOverlay::on_lbr_state_, this, std::placeholders::_1));
+        "lbr_state", 1, std::bind(&TorqueSineOverlay::on_lbr_state_, this, std::placeholders::_1));
 
     // get control rate from controller_manager
     auto update_rate =

--- a/lbr_demos/lbr_demos_cpp/src/wrench_sine_overlay.cpp
+++ b/lbr_demos/lbr_demos_cpp/src/wrench_sine_overlay.cpp
@@ -27,7 +27,7 @@ public:
 
     // create subscription to state
     lbr_state_sub_ = node_->create_subscription<lbr_fri_idl::msg::LBRState>(
-        "state", 1, std::bind(&WrenchSineOverlay::on_lbr_state_, this, std::placeholders::_1));
+        "lbr_state", 1, std::bind(&WrenchSineOverlay::on_lbr_state_, this, std::placeholders::_1));
 
     // get control rate from controller_manager
     auto update_rate =

--- a/lbr_demos/lbr_demos_py/lbr_demos_py/joint_sine_overlay.py
+++ b/lbr_demos/lbr_demos_py/lbr_demos_py/joint_sine_overlay.py
@@ -28,7 +28,7 @@ class JointSineOverlayNode(Node):
         # create subscription to state
         self._lbr_state = None
         self._lbr_state_sub_ = self.create_subscription(
-            LBRState, "state", self._on_lbr_state, 1
+            LBRState, "lbr_state", self._on_lbr_state, 1
         )
 
         # get control rate from controller_manager

--- a/lbr_demos/lbr_demos_py/lbr_demos_py/torque_sine_overlay.py
+++ b/lbr_demos/lbr_demos_py/lbr_demos_py/torque_sine_overlay.py
@@ -26,7 +26,7 @@ class TorqueSineOverlayNode(Node):
         # create subscription to state
         self._lbr_state = None
         self._lbr_state_sub = self.create_subscription(
-            LBRState, "state", self._on_lbr_state, 1
+            LBRState, "lbr_state", self._on_lbr_state, 1
         )
 
         # get control rate from controller_manager

--- a/lbr_demos/lbr_demos_py/lbr_demos_py/wrench_sine_overlay.py
+++ b/lbr_demos/lbr_demos_py/lbr_demos_py/wrench_sine_overlay.py
@@ -26,7 +26,7 @@ class WrenchSineOverlayNode(Node):
         # create subscription to state
         self._lbr_state = None
         self._lbr_state_sub = self.create_subscription(
-            LBRState, "state", self._on_lbr_state, 1
+            LBRState, "lbr_state", self._on_lbr_state, 1
         )
 
         # get control rate from controller_manager

--- a/lbr_description/ros2_control/lbr_controllers.yaml
+++ b/lbr_description/ros2_control/lbr_controllers.yaml
@@ -100,8 +100,8 @@
   ros__parameters:
     robot_name: lbr
     admittance:
-      mass: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
-      damping: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+      mass: [0.05, 0.05, 0.05, 0.005, 0.005, 0.005]
+      damping: [1., 1., 1., 0.1, 0.1, 0.1]
       stiffness: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     inv_jac_ctrl:
       chain_root: lbr_link_0

--- a/lbr_description/ros2_control/lbr_system_config.yaml
+++ b/lbr_description/ros2_control/lbr_system_config.yaml
@@ -31,16 +31,3 @@ hardware:
   # for position control, LBR works best in open_loop control mode
   # note that open_loop is overridden to false if LBR is in impedance or Cartesian impedance control mode
   open_loop: true
-estimated_ft_sensor: # estimates the external force-torque from the external joint torque values
-  enabled: true # whether to enable the force-torque estimation
-  update_rate: 100 # update rate for the force-torque estimation [Hz] (less or equal to controller manager update rate)
-  rt_prio: 30 # real-time priority for the force-torque estimation
-  chain_root: lbr_link_0
-  chain_tip: lbr_link_ee
-  damping: 0.2 # damping factor for the pseudo-inverse of the Jacobian
-  force_x_th: 2.0 # x-force threshold. Only if the force exceeds this value, the force will be considered
-  force_y_th: 2.0 # y-force threshold. Only if the force exceeds this value, the force will be considered
-  force_z_th: 2.0 # z-force threshold. Only if the force exceeds this value, the force will be considered
-  torque_x_th: 0.5 # x-torque threshold. Only if the torque exceeds this value, the torque will be considered
-  torque_y_th: 0.5 # y-torque threshold. Only if the torque exceeds this value, the torque will be considered
-  torque_z_th: 0.5 # z-torque threshold. Only if the torque exceeds this value, the torque will be considered

--- a/lbr_description/ros2_control/lbr_system_interface.xacro
+++ b/lbr_description/ros2_control/lbr_system_interface.xacro
@@ -60,30 +60,6 @@
                     <state_interface name="tracking_performance" />
                 </sensor>
 
-                <sensor
-                    name="estimated_ft_sensor">
-                    <param name="enabled">${system_config['estimated_ft_sensor']['enabled']}</param>
-                    <param name="update_rate">${system_config['estimated_ft_sensor']['update_rate']}</param>
-                    <param name="rt_prio">${system_config['estimated_ft_sensor']['rt_prio']}</param>
-                    <param name="chain_root">${system_config['estimated_ft_sensor']['chain_root']}</param>
-                    <param name="chain_tip">${system_config['estimated_ft_sensor']['chain_tip']}</param>
-                    <param name="damping">${system_config['estimated_ft_sensor']['damping']}</param>
-                    <param name="force_x_th">${system_config['estimated_ft_sensor']['force_x_th']}</param>
-                    <param name="force_y_th">${system_config['estimated_ft_sensor']['force_y_th']}</param>
-                    <param name="force_z_th">${system_config['estimated_ft_sensor']['force_z_th']}</param>
-                    <param name="torque_x_th">${system_config['estimated_ft_sensor']['torque_x_th']}</param>
-                    <param name="torque_y_th">${system_config['estimated_ft_sensor']['torque_y_th']}</param>
-                    <param name="torque_z_th">${system_config['estimated_ft_sensor']['torque_z_th']}</param>
-                    <xacro:if value="${system_config['estimated_ft_sensor']['enabled']}">
-                        <state_interface name="force.x" />
-                        <state_interface name="force.y" />
-                        <state_interface name="force.z" />
-                        <state_interface name="torque.x" />
-                        <state_interface name="torque.y" />
-                        <state_interface name="torque.z" />
-                    </xacro:if>
-                </sensor>
-
                 <!-- FRI Cartesian impedance control mode -->
                 <gpio
                     name="wrench">

--- a/lbr_fri_ros2/include/lbr_fri_ros2/ft_estimator.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/ft_estimator.hpp
@@ -70,23 +70,5 @@ protected:
   Eigen::Matrix<double, N_JNTS, 1> tau_ext_;
   Eigen::Matrix<double, CARTESIAN_DOF, 1> f_ext_raw_, f_ext_, f_ext_tf_;
 };
-
-class FTEstimator : public Worker {
-  /**
-   * @brief A simple class to run the FTEstimatorImpl asynchronously at a specified update rate.
-   *
-   */
-public:
-  FTEstimator(const std::shared_ptr<FTEstimatorImpl> ft_estimator,
-              const std::uint16_t &update_rate = 100);
-
-  inline std::string LOGGER_NAME() const override { return "lbr_fri_ros2::FTEstimator"; };
-
-protected:
-  void perform_work_() override;
-
-  std::shared_ptr<FTEstimatorImpl> ft_estimator_impl_ptr_;
-  std::uint16_t update_rate_;
-};
 } // namespace lbr_fri_ros2
 #endif // LBR_FRI_ROS2__FT_ESTIMATOR_HPP_

--- a/lbr_fri_ros2/src/ft_estimator.cpp
+++ b/lbr_fri_ros2/src/ft_estimator.cpp
@@ -37,18 +37,4 @@ void FTEstimatorImpl::reset() {
   f_ext_tf_.setZero();
   jacobian_inv_.setZero();
 }
-
-FTEstimator::FTEstimator(const std::shared_ptr<FTEstimatorImpl> ft_estimator_impl_ptr,
-                         const std::uint16_t &update_rate)
-    : ft_estimator_impl_ptr_(ft_estimator_impl_ptr), update_rate_(update_rate) {}
-
-void FTEstimator::perform_work_() {
-  running_ = true;
-  while (rclcpp::ok() && !should_stop_) {
-    auto start = std::chrono::high_resolution_clock::now();
-    ft_estimator_impl_ptr_->compute();
-    std::this_thread::sleep_until(start + std::chrono::nanoseconds(static_cast<int>(
-                                              1.e9 / static_cast<double>(update_rate_))));
-  }
-};
 } // namespace lbr_fri_ros2

--- a/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
@@ -24,7 +24,6 @@
 #include "lbr_fri_ros2/app.hpp"
 #include "lbr_fri_ros2/async_client.hpp"
 #include "lbr_fri_ros2/formatting.hpp"
-#include "lbr_fri_ros2/ft_estimator.hpp"
 #include "lbr_fri_ros2/guards/command_guard.hpp"
 #include "lbr_fri_ros2/guards/state_guard.hpp"
 #include "lbr_fri_ros2/interfaces/state.hpp"
@@ -56,21 +55,6 @@ protected:
     bool open_loop{true};
   };
 
-  struct EstimatedFTSensorParameters {
-    bool enabled{true};
-    std::uint16_t update_rate{100};
-    int32_t rt_prio{30};
-    std::string chain_root{"lbr_link_0"};
-    std::string chain_tip{"lbr_link_ee"};
-    double damping{0.2};
-    double force_x_th{2.0};
-    double force_y_th{2.0};
-    double force_z_th{2.0};
-    double torque_x_th{0.5};
-    double torque_y_th{0.5};
-    double torque_z_th{0.5};
-  };
-
   struct CommandKeys {
     lbr_fri_ros2::jnt_name_array_t joint_position, torque;
     lbr_fri_ros2::cart_name_array_t wrench;
@@ -99,7 +83,6 @@ protected:
     std::string sample_time, session_state, connection_quality, safety_state, operation_mode,
         drive_state, client_command_mode, overlay_type, control_mode, time_stamp_sec,
         time_stamp_nano_sec, tracking_performance;
-    lbr_fri_ros2::cart_name_array_t estimated_ft;
 
     void populate_keys(const hardware_interface::HardwareInfo &info) {
       for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
@@ -127,13 +110,6 @@ protected:
       time_stamp_sec = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC;
       time_stamp_nano_sec = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC;
       tracking_performance = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TRACKING_PERFORMANCE;
-
-      estimated_ft[0] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_X;
-      estimated_ft[1] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Y;
-      estimated_ft[2] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Z;
-      estimated_ft[3] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_X;
-      estimated_ft[4] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Y;
-      estimated_ft[5] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Z;
     }
   };
 
@@ -145,9 +121,8 @@ protected:
   static constexpr uint8_t LBR_FRI_STATE_INTERFACE_SIZE = 6;
 #endif
   static constexpr uint8_t LBR_FRI_COMMAND_INTERFACE_SIZE = 2;
-  static constexpr uint8_t LBR_FRI_SENSORS = 2;
+  static constexpr uint8_t LBR_FRI_SENSORS = 1;
   static constexpr uint8_t AUXILIARY_SENSOR_SIZE = 12;
-  static constexpr uint8_t ESTIMATED_FT_SENSOR_SIZE = 6;
   static constexpr uint8_t GPIO_SIZE = 1;
 
 public:
@@ -178,7 +153,6 @@ public:
 protected:
   // setup
   bool parse_parameters_();
-  bool parse_ft_parameters_();
   void nan_command_interfaces_();
   void nan_state_interfaces_();
   bool verify_number_of_joints_();
@@ -186,7 +160,6 @@ protected:
   bool verify_joint_state_interfaces_();
   bool verify_sensors_();
   bool verify_auxiliary_sensor_();
-  bool verify_estimated_ft_sensor_();
   bool verify_gpios_();
 
   // monitor end of commanding active
@@ -195,7 +168,6 @@ protected:
 
   // robot parameters
   SystemInterfaceParameters parameters_;
-  EstimatedFTSensorParameters ft_parameters_;
 
   // robot driver
   std::shared_ptr<lbr_fri_ros2::AsyncClient> async_client_ptr_;
@@ -212,11 +184,6 @@ protected:
   void nan_last_states_();
   void update_last_states_();
   void compute_velocity_();
-
-  // additional force-torque state interface
-  lbr_fri_ros2::cart_array_t ft_;
-  std::shared_ptr<lbr_fri_ros2::FTEstimatorImpl> ft_estimator_impl_ptr_;
-  std::unique_ptr<lbr_fri_ros2::FTEstimator> ft_estimator_ptr_;
 
   // command and state buffers
   lbr_fri_idl::msg::LBRCommand lbr_command_;

--- a/lbr_ros2_control/src/controllers/admittance_controller.cpp
+++ b/lbr_ros2_control/src/controllers/admittance_controller.cpp
@@ -131,7 +131,8 @@ AdmittanceController::update(const rclcpp::Time & /*time*/, const rclcpp::Durati
   admittance_impl_ptr_->compute(f_ext_, delta_x_, dx_, ddx_);
 
   // integrate ddx_ to command velocity
-  twist_command_ = ddx_ * dt;
+  dx_ += ddx_ * dt;
+  twist_command_ = dx_;
 
   if (!inv_jac_ctrl_impl_ptr_) {
     RCLCPP_ERROR(this->get_node()->get_logger(), "Inverse Jacobian controller not initialized.");

--- a/lbr_ros2_control/src/controllers/lbr_state_broadcaster.cpp
+++ b/lbr_ros2_control/src/controllers/lbr_state_broadcaster.cpp
@@ -16,7 +16,7 @@ LBRStateBroadcaster::state_interface_configuration() const {
 controller_interface::CallbackReturn LBRStateBroadcaster::on_init() {
   try {
     state_publisher_ptr_ =
-        this->get_node()->create_publisher<lbr_fri_idl::msg::LBRState>("state", 1);
+        this->get_node()->create_publisher<lbr_fri_idl::msg::LBRState>("lbr_state", 1);
 
     rt_state_publisher_ptr_ =
         std::make_shared<realtime_tools::RealtimePublisher<lbr_fri_idl::msg::LBRState>>(

--- a/lbr_ros2_control/src/system_interface.cpp
+++ b/lbr_ros2_control/src/system_interface.cpp
@@ -56,25 +56,6 @@ SystemInterface::on_init(const hardware_interface::HardwareComponentInterfacePar
     return controller_interface::CallbackReturn::ERROR;
   }
 
-  // setup force-torque estimator
-  if (!parse_ft_parameters_()) {
-    return controller_interface::CallbackReturn::ERROR;
-  }
-  if (ft_parameters_.enabled) {
-    ft_estimator_impl_ptr_ = std::make_shared<lbr_fri_ros2::FTEstimatorImpl>(
-        info_.original_xml, ft_parameters_.chain_root, ft_parameters_.chain_tip,
-        lbr_fri_ros2::cart_array_t{
-            ft_parameters_.force_x_th,
-            ft_parameters_.force_y_th,
-            ft_parameters_.force_z_th,
-            ft_parameters_.torque_x_th,
-            ft_parameters_.torque_y_th,
-            ft_parameters_.torque_z_th,
-        });
-    ft_estimator_ptr_ = std::make_unique<lbr_fri_ros2::FTEstimator>(ft_estimator_impl_ptr_,
-                                                                    ft_parameters_.update_rate);
-  }
-
   // populate the keys
   command_keys_.populate_keys(info_);
   state_keys_.populate_keys(info_);
@@ -170,27 +151,12 @@ controller_interface::CallbackReturn SystemInterface::on_activate(const rclcpp_l
     }
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
-
-  // ft sensor
-  if (!ft_estimator_ptr_ && ft_parameters_.enabled) {
-    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                        lbr_fri_ros2::ColorScheme::ERROR
-                            << "Failed to instantiate FTEstimator despite user request."
-                            << lbr_fri_ros2::ColorScheme::ENDC);
-    return controller_interface::CallbackReturn::ERROR;
-  }
-  if (ft_estimator_ptr_) {
-    ft_estimator_ptr_->run_async(ft_parameters_.rt_prio);
-  }
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::CallbackReturn
 SystemInterface::on_deactivate(const rclcpp_lifecycle::State &) {
   app_ptr_->request_stop();
-  if (ft_estimator_ptr_) {
-    ft_estimator_ptr_->request_stop();
-  }
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
@@ -225,7 +191,6 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
                             << lbr_fri_ros2::ColorScheme::ENDC);
     app_ptr_->request_stop();
     app_ptr_->close_udp_socket();
-    ft_estimator_ptr_->request_stop();
     return hardware_interface::return_type::ERROR;
   }
 
@@ -261,18 +226,6 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
   // additional velocity state interface
   compute_velocity_();
   update_last_states_();
-
-  // additional force-torque state interface
-  if (ft_parameters_.enabled) {
-    // note that (if enabled) the computation is performed asynchronously to not block the main
-    // thread
-    ft_estimator_impl_ptr_->set_q(lbr_state_.measured_joint_position);
-    ft_estimator_impl_ptr_->set_tau_ext(lbr_state_.external_torque);
-    ft_estimator_impl_ptr_->get_f_ext_tf(ft_);
-    for (std::size_t i = 0; i < lbr_fri_ros2::CARTESIAN_DOF; ++i) {
-      set_state(state_keys_.estimated_ft[i], ft_[i]);
-    }
-  }
   return hardware_interface::return_type::OK;
 }
 
@@ -375,35 +328,6 @@ bool SystemInterface::parse_parameters_() {
   return true;
 }
 
-bool SystemInterface::parse_ft_parameters_() {
-  try {
-    std::transform(info_.sensors[1].parameters.at("enabled").begin(),
-                   info_.sensors[1].parameters.at("enabled").end(),
-                   info_.sensors[1].parameters.at("enabled").begin(),
-                   ::tolower); // convert to lower case
-    const auto &estimated_ft_sensor = info_.sensors[1];
-    ft_parameters_.enabled = estimated_ft_sensor.parameters.at("enabled") == "true";
-    ft_parameters_.update_rate = std::stoul(estimated_ft_sensor.parameters.at("update_rate"));
-    ft_parameters_.rt_prio = std::stoi(estimated_ft_sensor.parameters.at("rt_prio"));
-    ft_parameters_.chain_root = estimated_ft_sensor.parameters.at("chain_root");
-    ft_parameters_.chain_tip = estimated_ft_sensor.parameters.at("chain_tip");
-    ft_parameters_.damping = std::stod(estimated_ft_sensor.parameters.at("damping"));
-    ft_parameters_.force_x_th = std::stod(estimated_ft_sensor.parameters.at("force_x_th"));
-    ft_parameters_.force_y_th = std::stod(estimated_ft_sensor.parameters.at("force_y_th"));
-    ft_parameters_.force_z_th = std::stod(estimated_ft_sensor.parameters.at("force_z_th"));
-    ft_parameters_.torque_x_th = std::stod(estimated_ft_sensor.parameters.at("torque_x_th"));
-    ft_parameters_.torque_y_th = std::stod(estimated_ft_sensor.parameters.at("torque_y_th"));
-    ft_parameters_.torque_z_th = std::stod(estimated_ft_sensor.parameters.at("torque_z_th"));
-  } catch (const std::out_of_range &e) {
-    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                        lbr_fri_ros2::ColorScheme::ERROR
-                            << "Failed to parse force-torque sensor parameters with: " << e.what()
-                            << lbr_fri_ros2::ColorScheme::ENDC);
-    return false;
-  }
-  return true;
-}
-
 void SystemInterface::nan_command_interfaces_() {
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
     set_command(command_keys_.joint_position[i], std::numeric_limits<double>::quiet_NaN());
@@ -446,9 +370,6 @@ void SystemInterface::nan_state_interfaces_() {
 
   // additional velocity state interface
   velocity_.fill(std::numeric_limits<double>::quiet_NaN());
-
-  // additional force-torque state interface
-  ft_.fill(std::numeric_limits<double>::quiet_NaN());
 }
 
 bool SystemInterface::verify_number_of_joints_() {
@@ -540,11 +461,6 @@ bool SystemInterface::verify_sensors_() {
   if (!verify_auxiliary_sensor_()) {
     return false;
   }
-  if (ft_parameters_.enabled) {
-    if (!verify_estimated_ft_sensor_()) {
-      return false;
-    }
-  }
   return true;
 }
 
@@ -583,41 +499,6 @@ bool SystemInterface::verify_auxiliary_sensor_() {
       RCLCPP_ERROR_STREAM(get_node()->get_logger(),
                           lbr_fri_ros2::ColorScheme::ERROR
                               << "Sensor '" << auxiliary_sensor.name.c_str()
-                              << "' received invalid state interface '" << si.name.c_str() << "'"
-                              << lbr_fri_ros2::ColorScheme::ENDC);
-      return false;
-    }
-  }
-  return true;
-}
-
-bool SystemInterface::verify_estimated_ft_sensor_() {
-  const auto &estimated_ft_sensor = info_.sensors[1];
-  if (estimated_ft_sensor.name != HW_IF_ESTIMATED_FT_PREFIX) {
-    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                        lbr_fri_ros2::ColorScheme::ERROR
-                            << "Sensor '" << estimated_ft_sensor.name.c_str()
-                            << "' received invalid name. Expected '" << HW_IF_ESTIMATED_FT_PREFIX
-                            << "'" << lbr_fri_ros2::ColorScheme::ENDC);
-    return false;
-  }
-  if (estimated_ft_sensor.state_interfaces.size() != ESTIMATED_FT_SENSOR_SIZE) {
-    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                        lbr_fri_ros2::ColorScheme::ERROR
-                            << "Sensor '" << estimated_ft_sensor.name.c_str()
-                            << "' received invalid number of state interfaces. Received '"
-                            << estimated_ft_sensor.state_interfaces.size() << "', expected '"
-                            << static_cast<int>(ESTIMATED_FT_SENSOR_SIZE) << "'"
-                            << lbr_fri_ros2::ColorScheme::ENDC);
-    return false;
-  }
-  // check only valid interfaces are defined
-  for (const auto &si : estimated_ft_sensor.state_interfaces) {
-    if (si.name != HW_IF_FORCE_X && si.name != HW_IF_FORCE_Y && si.name != HW_IF_FORCE_Z &&
-        si.name != HW_IF_TORQUE_X && si.name != HW_IF_TORQUE_Y && si.name != HW_IF_TORQUE_Z) {
-      RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                          lbr_fri_ros2::ColorScheme::ERROR
-                              << "Sensor '" << estimated_ft_sensor.name.c_str()
                               << "' received invalid state interface '" << si.name.c_str() << "'"
                               << lbr_fri_ros2::ColorScheme::ENDC);
       return false;

--- a/lbr_ros2_control/src/system_interface.cpp
+++ b/lbr_ros2_control/src/system_interface.cpp
@@ -146,6 +146,16 @@ controller_interface::CallbackReturn SystemInterface::on_activate(const rclcpp_l
                            << lbr_fri_ros2::ColorScheme::BOLD << lbr_fri_ros2::ColorScheme::OKBLUE
                            << lbr_fri_ros2::EnumMaps::session_state_map(state.session_state)
                            << lbr_fri_ros2::ColorScheme::ENDC << "'.");
+    if (state.session_state == KUKA::FRI::ESessionState::IDLE) {
+      RCLCPP_ERROR_STREAM(
+          get_node()->get_logger(),
+          lbr_fri_ros2::ColorScheme::ERROR
+              << "Robot in '"
+              << lbr_fri_ros2::EnumMaps::session_state_map(KUKA::FRI::ESessionState::IDLE)
+              << "' state. Please restart the FRI server." << lbr_fri_ros2::ColorScheme::ENDC);
+      app_ptr_->close_udp_socket(); // no need to request stop since already stopped when IDLE
+      return controller_interface::CallbackReturn::ERROR;
+    }
     if (!rclcpp::ok()) {
       return controller_interface::CallbackReturn::ERROR;
     }


### PR DESCRIPTION
- [ ] Force-torque estimation update #292
  - [x] Remove force-torque estimation from system interface
  - [ ] Force-torque estimation as chainable controller
- [x] `/lbr/state` -> `/lbr/lbr_state` consistent with #271
- [x] Fix the integration in the admittance controller #320
- [x] Exit `on_activate` with error on `IDLE` #321 