### PR TITLE
Remove FT estimation from system interface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,33 +1,66 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package LBR FRI ROS 2 Stack
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Jazzy v2.4.0 (TBD)
+Jazzy v2.4.0 (2025-12-06)
 --------------------------
+This release removes the asynchronous force-torque estimation from the system interface (introduced in https://github.com/lbr-stack/lbr_fri_ros2_stack/releases/tag/humble-v2.2.0)
+and instead provides a synchronous estimation in the form of a chainable ROS 2 controller. It further adds some controller updates, API fixes, and safety improvements. 
+
+* ``lbr_bringup``: Added new chainable wrench interface controller to ``hardware.launch.py`` and added launch event handler for preceeding controllers 
+* ``lbr_demos``: Updated topics ``/lbr/state`` -> ``/lbr/lbr_state``
+* ``lbr_description``:
+
+  * Removed now redundant ``estimated_ft_sensor`` from ``lbr_system_config.yaml`` and removed thus unused ``hardware`` prefix
+  * Removed all ``hardware`` specifiers from ``lbr_system_interface.xacro``
+* ``lbr_fri_ros2``:
+
+  * Removed now redundant asynchronous ``lbr_fri_ros2::FTEstimator`` worker (also removed from ``lbr_ros2_control::SystemInterface``)
+  * Renamed ``lbr_fri_ros::FTEstimatorImpl`` -> ``lbr_fri_ros2::WrenchEstimator``
+  * Fixed twist clamping bug: https://github.com/lbr-stack/lbr_fri_ros2_stack/issues/313
 * ``lbr_ros2_control``:
 
-  * ``/lbr/state`` -> ``/lbr/lbr_state`` consistent with https://github.com/lbr-stack/lbr_fri_ros2_stack/pull/271.
-  * Fixes missing integration step in the admittance controller: https://github.com/lbr-stack/lbr_fri_ros2_stack/issues/320.
-  * Exit ``on_activate`` in ``lbr_ros2_control::SystemInterface`` with error on ``IDLE``: https://github.com/lbr-stack/lbr_fri_ros2_stack/issues/321.
+  * Changes to ``lbr_ros2_control::SystemInterface``:
+
+    * Removed force-torque estimation from ``lbr_ros2_control::SystemInterface``
+    * Exit ``on_activate`` in ``lbr_ros2_control::SystemInterface`` with error on ``IDLE``: https://github.com/lbr-stack/lbr_fri_ros2_stack/issues/321
+  * Changes to controllers:  
+
+    * ``lbr_ros2_control::EstimatedWrenchInterface``: Added new chainable controller for synchronous force-torque estimation and state interface
+    * ``lbr_ros2_control::TwistController``: Stop twist controller on any joint limits: https://github.com/lbr-stack/lbr_fri_ros2_stack/issues/314
+    * ``lbr_ros2_control::LBRStateBroadcaster``:
+
+      * ``/lbr/state`` -> ``/lbr/lbr_state`` consistent with https://github.com/lbr-stack/lbr_fri_ros2_stack/pull/271
+      * Removed deprecated ``trylock()`` from ``lbr_ros2_control::LBRStateBroadcaster``: https://github.com/ros-controls/realtime_tools/pull/323
+  * ``lbr_ros2_control::AdmittanceController``:
+
+    * Fixed missing integration step in the admittance controller: https://github.com/lbr-stack/lbr_fri_ros2_stack/issues/320
+    * Added an adjustable load data safety tolerance: https://github.com/lbr-stack/lbr_fri_ros2_stack/issues/325
+    * Replaced veloctiy command filtering with force state filtering: https://github.com/lbr-stack/lbr_fri_ros2_stack/issues/327
+* Related pull requests:
+
+  * Twist clamping and ``lbr_ros2_control::TwistController`` controller updates: https://github.com/lbr-stack/lbr_fri_ros2_stack/pull/315
+  * ``lbr_ros2_control::AdmittanceController`` integration step and ``lbr_ros2_control::SystemInterface::on_activate`` exit: https://github.com/lbr-stack/lbr_fri_ros2_stack/pull/322
+  * ``lbr_ros2_control::SystemInterface`` force-torque estimation removal (including new chainable controller): https://github.com/lbr-stack/lbr_fri_ros2_stack/pull/324
 
 Jazzy v2.3.0 (2025-11-21)
 --------------------------
 * ``lbr_fri_ros2``:
 
   * Interfaces now default to return by value for simplicity.
-  * Added a new ``StateGuard`` that tests for load data calibration on activation in compliant control modes and shuts the connection otherwise.
-  * Instead of disconnecting on ``CommandGuard`` limits, ``CommandInterfaces`` now execute a neutral command.
+  * Added a new ``StateGuard`` that tests for load data calibration on activation in compliant control modes and shuts the connection otherwise
+  * Instead of disconnecting on ``CommandGuard`` limits, ``CommandInterfaces`` now execute a neutral command
 * ``lbr_description``:
 
   * Updated joint limits (upper / lower) to be 1 degree stricter to avoid hardware limits.
   * Added ``safety_controller`` tag to URDF files. Note, in Jazzy this is only utilised when ``enforce_command_limits:=true`` for the controller manager (default configured in ``lbr_controllers.yaml`` here). 
 * ``lbr_ros2_control``:
 
-  * Migrated to Jazzy following guidelines at https://control.ros.org/jazzy/doc/ros2_control/doc/migration.html#migration-of-command-stateinterfaces.
+  * Migrated to Jazzy following guidelines at https://control.ros.org/jazzy/doc/ros2_control/doc/migration.html#migration-of-command-stateinterfaces
   * Removed the default error from ``AdmittanceController`` with the introduction of load data checks. Also now supports the default ``lbr_system_config.yaml``.
-  * WARN: KUKA's Cartesian impedance controller seems quite prone to singularities, and should thus be used with caution and only in ``T1`` mode.
+  * WARN: KUKA's Cartesian impedance controller seems quite prone to singularities, and should thus be used with caution and only in ``T1`` mode
 
     * ``LBRWrenchCommandController`` (uses Cartesian impedance) is now a ``ChainableControllerInterface`` to support separate wrench and joint position commands: https://github.com/lbr-stack/lbr_fri_ros2_stack/issues/250
-    * Future releases will chain the ``LBRTorqueCommandController``, which uses KUKA's joint impedance controller without singularity issues.
+    * Future releases will chain the ``LBRTorqueCommandController``, which uses KUKA's joint impedance controller without singularity issues
     * Topics were updated to reflect the chained controller structure:
 
       * ``/lbr/wrench`` -> ``/lbr/lbr_wrench_command``
@@ -79,10 +112,10 @@ Humble v2.1.2 (2024-10-18)
 
 Humble v2.1.1 (2024-09-27)
 --------------------------
-* Adds support for the new Gazebo and removes support for Gazebo Classic (End-of-Life January 2025, refer https://community.gazebosim.org/t/gazebo-classic-end-of-life/2563).
+* Adds support for the new Gazebo and removes support for Gazebo Classic (End-of-Life January 2025, refer https://community.gazebosim.org/t/gazebo-classic-end-of-life/2563)
 
   * ``lbr_bringup``: Updated launch files and dependencies.
-  * ``lbr_description``: Updated ``<gazebo>`` tag to include Gazebo plugin (see https://github.com/ros-controls/gz_ros2_control/tree/humble). 
+  * ``lbr_description``: Updated ``<gazebo>`` tag to include Gazebo plugin (see https://github.com/ros-controls/gz_ros2_control/tree/humble)
   * ``lbr_ros2_control``: Changed ``gazebo_ros2_control/GazeboSystem`` -> ``ign_ros2_control/IgnitionSystem```
 
 Humble v2.1.0 (2024-09-10)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,6 +19,6 @@ authors:
 
 
 title: "LBR-Stack: ROS 2 and Python Integration of KUKA FRI for Med and IIWA Robots"
-version: 2.3.0
+version: 2.4.0
 doi: 10.21105/joss.06138
-date-released: 2025-03-26
+date-released: 2025-12-06

--- a/README.md
+++ b/README.md
@@ -15,10 +15,18 @@ ROS 2 packages for the KUKA LBR, including communication to the real robot via t
             <th align="left" width="25%">LBR Med 14 R820</th>
         </tr>
         <tr>
-            <td align="center"><img src="https://raw.githubusercontent.com/lbr-stack/lbr_fri_ros2_stack/rolling/lbr_fri_ros2_stack/doc/img/foxglove/iiwa7_r800.png" alt="LBR IIWA 7 R800"></td>
-            <td align="center"><img src="https://raw.githubusercontent.com/lbr-stack/lbr_fri_ros2_stack/rolling/lbr_fri_ros2_stack/doc/img/foxglove/iiwa14_r820.png" alt="LBR IIWA 14 R820"></td>
-            <td align="center"><img src="https://raw.githubusercontent.com/lbr-stack/lbr_fri_ros2_stack/rolling/lbr_fri_ros2_stack/doc/img/foxglove/med7_r800.png" alt="LBR Med 7 R800"></td>
-            <td align="center"><img src="https://raw.githubusercontent.com/lbr-stack/lbr_fri_ros2_stack/rolling/lbr_fri_ros2_stack/doc/img/foxglove/med14_r820.png" alt="LBR Med 14 R820"></td>
+            <td align="center">
+                <img src="https://raw.githubusercontent.com/lbr-stack/lbr_fri_ros2_stack/rolling/lbr_fri_ros2_stack/doc/img/foxglove/iiwa7_r800.png" alt="LBR IIWA 7 R800">
+            </td>
+            <td align="center">
+                <img src="https://raw.githubusercontent.com/lbr-stack/lbr_fri_ros2_stack/rolling/lbr_fri_ros2_stack/doc/img/foxglove/iiwa14_r820.png" alt="LBR IIWA 14 R820">
+            </td>
+            <td align="center">
+                <img src="https://raw.githubusercontent.com/lbr-stack/lbr_fri_ros2_stack/rolling/lbr_fri_ros2_stack/doc/img/foxglove/med7_r800.png" alt="LBR Med 7 R800">
+            </td>
+            <td align="center">
+                <img src="https://raw.githubusercontent.com/lbr-stack/lbr_fri_ros2_stack/rolling/lbr_fri_ros2_stack/doc/img/foxglove/med14_r820.png" alt="LBR Med 14 R820">
+            </td>
         </tr>
     </table>
 </body>
@@ -86,15 +94,28 @@ Full documentation available on [Read the Docs](https://lbr-stack.readthedocs.io
 Now, run the [demos](https://lbr-stack.readthedocs.io/en/latest/lbr_fri_ros2_stack/lbr_demos/doc/lbr_demos.html). To get started with the real robot, checkout the [Hardware Setup](https://lbr-stack.readthedocs.io/en/latest/lbr_fri_ros2_stack/lbr_fri_ros2_stack/doc/hardware_setup.html).
 
 ## Repositories Using This Project
-- [KUKA ROS2 controllers](https://github.com/idra-lab/kuka_lbr_control) — A repository for controlling KUKA LBR iiwa and med robots using various control algorithms.
+- [KUKA ROS 2 Controllers](https://github.com/idra-lab/kuka_lbr_control): A repository for controlling KUKA LBR IIWA and Med robots using various control algorithms.
 
-<div align="center">
-
-| Kinematics Control | Gravity compensation | Impedance Control |
-| :----------------- | :--------------------| :---------------- |
-| <img src='https://raw.githubusercontent.com/idra-lab/kuka_lbr_control/main/assets/videos/kin.gif' width=360/> | <img src='https://raw.githubusercontent.com/idra-lab/kuka_lbr_control/main/assets/videos/grav.gif' width=360/> | <img src='https://raw.githubusercontent.com/idra-lab/kuka_lbr_control/main/assets/videos/imp.gif' width=360/> |
-
-</div>
+<body>
+    <table style="width:100%; table-layout:fixed;">
+        <tr>
+            <th  align="left" width="33%">Kinematics Control</th>
+            <th  align="left" width="33%">Gravity Compensation</th>
+            <th  align="left" width="33%">Impedance Control</th>
+        </tr>
+        <tr>
+            <td align="center">
+                <img src="https://raw.githubusercontent.com/idra-lab/kuka_lbr_control/main/assets/videos/kin.gif" alt="Kinematics Control">
+            </td>
+            <td align="center">
+                <img src="https://raw.githubusercontent.com/idra-lab/kuka_lbr_control/main/assets/videos/grav.gif" alt="Gravity Compensation">
+            </td>
+            <td align="center">
+                <img src="https://raw.githubusercontent.com/idra-lab/kuka_lbr_control/main/assets/videos/imp.gif" alt="Impedance Control">
+            </td>
+        </tr>
+    </table>
+</body>
 
 ## Citation
 If you enjoyed using this repository for your work, we would really appreciate ❤️ if you could leave a ⭐ and / or cite it, as it helps us to continue offering support.

--- a/lbr_bringup/launch/hardware.launch.py
+++ b/lbr_bringup/launch/hardware.launch.py
@@ -1,6 +1,6 @@
 from launch import LaunchDescription
 from launch.actions import RegisterEventHandler
-from launch.event_handlers import OnProcessStart
+from launch.event_handlers import OnExecutionComplete, OnProcessStart
 from launch.substitutions import LaunchConfiguration
 from lbr_bringup.description import LBRDescriptionMixin
 from lbr_bringup.ros2_control import LBRROS2ControlMixin
@@ -31,27 +31,42 @@ def generate_launch_description() -> LaunchDescription:
     ros2_control_node = LBRROS2ControlMixin.node_ros2_control(use_sim_time=False)
     ld.add_action(ros2_control_node)
 
-    # joint state broad caster and controller on ros2 control node start
+    # controllers on ros2 control node start
     joint_state_broadcaster = LBRROS2ControlMixin.node_controller_spawner(
         controller="joint_state_broadcaster"
     )
-    force_torque_broadcaster = LBRROS2ControlMixin.node_controller_spawner(
-        controller="force_torque_broadcaster"
+    estimated_wrench_broadcaster = LBRROS2ControlMixin.node_controller_spawner(
+        controller="estimated_wrench_broadcaster"
     )
     lbr_state_broadcaster = LBRROS2ControlMixin.node_controller_spawner(
         controller="lbr_state_broadcaster"
+    )
+
+    preceding_controllers_event_handler = RegisterEventHandler(
+        OnProcessStart(
+            target_action=ros2_control_node,
+            on_start=[
+                joint_state_broadcaster,
+                estimated_wrench_broadcaster,
+                lbr_state_broadcaster,
+            ],
+        )
+    )
+    ld.add_action(preceding_controllers_event_handler)
+
+    # controllers on estimated wrench broadcaster
+    force_torque_broadcaster = LBRROS2ControlMixin.node_controller_spawner(
+        controller="force_torque_broadcaster"
     )
     controller = LBRROS2ControlMixin.node_controller_spawner(
         controller=LaunchConfiguration("ctrl")
     )
 
     controller_event_handler = RegisterEventHandler(
-        OnProcessStart(
-            target_action=ros2_control_node,
-            on_start=[
-                joint_state_broadcaster,
+        OnExecutionComplete(
+            target_action=estimated_wrench_broadcaster,  # estimated wrench broadcaster is chained and exposes external wrench estimate state interfaces
+            on_completion=[
                 force_torque_broadcaster,
-                lbr_state_broadcaster,
                 controller,
             ],
         )

--- a/lbr_bringup/launch/hardware.launch.py
+++ b/lbr_bringup/launch/hardware.launch.py
@@ -35,8 +35,8 @@ def generate_launch_description() -> LaunchDescription:
     joint_state_broadcaster = LBRROS2ControlMixin.node_controller_spawner(
         controller="joint_state_broadcaster"
     )
-    estimated_wrench_broadcaster = LBRROS2ControlMixin.node_controller_spawner(
-        controller="estimated_wrench_broadcaster"
+    estimated_wrench_interface = LBRROS2ControlMixin.node_controller_spawner(
+        controller="estimated_wrench_interface"
     )
     lbr_state_broadcaster = LBRROS2ControlMixin.node_controller_spawner(
         controller="lbr_state_broadcaster"
@@ -47,14 +47,14 @@ def generate_launch_description() -> LaunchDescription:
             target_action=ros2_control_node,
             on_start=[
                 joint_state_broadcaster,
-                estimated_wrench_broadcaster,
+                estimated_wrench_interface,
                 lbr_state_broadcaster,
             ],
         )
     )
     ld.add_action(preceding_controllers_event_handler)
 
-    # controllers on estimated wrench broadcaster
+    # controllers on estimated wrench interface
     force_torque_broadcaster = LBRROS2ControlMixin.node_controller_spawner(
         controller="force_torque_broadcaster"
     )
@@ -64,7 +64,7 @@ def generate_launch_description() -> LaunchDescription:
 
     controller_event_handler = RegisterEventHandler(
         OnExecutionComplete(
-            target_action=estimated_wrench_broadcaster,  # estimated wrench broadcaster is chained and exposes external wrench estimate state interfaces
+            target_action=estimated_wrench_interface,  # estimated wrench interface is chained and exposes external wrench estimate state interfaces
             on_completion=[
                 force_torque_broadcaster,
                 controller,

--- a/lbr_bringup/package.xml
+++ b/lbr_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_bringup</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>LBR launch files.</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
   <license>Apache-2.0</license>

--- a/lbr_demos/lbr_demos_advanced_cpp/package.xml
+++ b/lbr_demos/lbr_demos_advanced_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_demos_advanced_cpp</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>Advanced C++ demos for the lbr_ros2_control.</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
   <license>Apache-2.0</license>

--- a/lbr_demos/lbr_demos_advanced_py/package.xml
+++ b/lbr_demos/lbr_demos_advanced_py/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_demos_advanced_py</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>Advanced Python demos for the lbr_ros2_control.</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
   <maintainer email="mower.chris@gmail.com">cmower</maintainer>

--- a/lbr_demos/lbr_demos_advanced_py/setup.py
+++ b/lbr_demos/lbr_demos_advanced_py/setup.py
@@ -6,7 +6,7 @@ package_name = "lbr_demos_advanced_py"
 
 setup(
     name=package_name,
-    version="2.3.0",
+    version="2.4.0",
     packages=[package_name],
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),

--- a/lbr_demos/lbr_demos_cpp/package.xml
+++ b/lbr_demos/lbr_demos_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_demos_cpp</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>C++ demos for lbr_ros2_control.</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
   <license>Apache-2.0</license>

--- a/lbr_demos/lbr_demos_py/package.xml
+++ b/lbr_demos/lbr_demos_py/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_demos_py</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>Python demos for lbr_ros2_control.</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
   <license>Apache-2.0</license>

--- a/lbr_demos/lbr_demos_py/setup.py
+++ b/lbr_demos/lbr_demos_py/setup.py
@@ -4,7 +4,7 @@ package_name = "lbr_demos_py"
 
 setup(
     name=package_name,
-    version="2.3.0",
+    version="2.4.0",
     packages=[package_name],
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),

--- a/lbr_demos/lbr_moveit/package.xml
+++ b/lbr_demos/lbr_moveit/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_moveit</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>MoveIt demos for the LBRs</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
   <license>Apache-2.0</license>

--- a/lbr_demos/lbr_moveit/setup.py
+++ b/lbr_demos/lbr_moveit/setup.py
@@ -4,7 +4,7 @@ package_name = "lbr_moveit"
 
 setup(
     name=package_name,
-    version="2.3.0",
+    version="2.4.0",
     packages=find_packages(exclude=["test"]),
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),

--- a/lbr_demos/lbr_moveit_cpp/package.xml
+++ b/lbr_demos/lbr_moveit_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_moveit_cpp</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>Demo for using MoveIt C++ API.</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
   <license>Apache-2.0</license>

--- a/lbr_description/package.xml
+++ b/lbr_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_description</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>KUKA LBR description files</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
   <license>Apache-2.0</license>

--- a/lbr_description/ros2_control/lbr_controllers.yaml
+++ b/lbr_description/ros2_control/lbr_controllers.yaml
@@ -13,6 +13,9 @@
       type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
 
     # LBR ROS 2 control broadcasters
+    estimated_wrench_broadcaster:
+      type: lbr_ros2_control/EstimatedWrenchBroadcaster
+
     lbr_state_broadcaster:
       type: lbr_ros2_control/LBRStateBroadcaster
 
@@ -46,6 +49,20 @@
     sensor_name: estimated_ft_sensor
 
 # LBR ROS 2 control broadcasters
+/**/estimated_wrench_broadcaster:
+  ros__parameters:
+    robot_name: lbr
+    wrench_estimator_parameters:
+      chain_root: lbr_link_0
+      chain_tip: lbr_link_ee
+      damping: 0.2
+      force_x_th: 2.0
+      force_y_th: 2.0
+      force_z_th: 2.0
+      torque_x_th: 0.5
+      torque_y_th: 0.5
+      torque_z_th: 0.5
+
 /**/lbr_state_broadcaster:
   ros__parameters:
     robot_name: lbr

--- a/lbr_description/ros2_control/lbr_controllers.yaml
+++ b/lbr_description/ros2_control/lbr_controllers.yaml
@@ -13,8 +13,8 @@
       type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
 
     # LBR ROS 2 control broadcasters
-    estimated_wrench_broadcaster:
-      type: lbr_ros2_control/EstimatedWrenchBroadcaster
+    estimated_wrench_interface:
+      type: lbr_ros2_control/EstimatedWrenchInterface
 
     lbr_state_broadcaster:
       type: lbr_ros2_control/LBRStateBroadcaster
@@ -45,14 +45,14 @@
 # ROS 2 control broadcasters
 /**/force_torque_broadcaster:
   ros__parameters:
-    frame_id: lbr_link_ee # namespace: https://github.com/ros2/rviz/issues/1103
-    sensor_name: estimated_ft_sensor
+    frame_id: lbr_link_ee # note: frame_id must equal estimated_wrench_interface.wrench_estimator.chain_tip; namespace: https://github.com/ros2/rviz/issues/1103
+    sensor_name: estimated_wrench_interface # note: name must equal estimated_wrench_interface node name (chained)
 
 # LBR ROS 2 control broadcasters
-/**/estimated_wrench_broadcaster:
+/**/estimated_wrench_interface:
   ros__parameters:
     robot_name: lbr
-    wrench_estimator_parameters:
+    wrench_estimator:
       chain_root: lbr_link_0
       chain_tip: lbr_link_ee
       damping: 0.2
@@ -116,6 +116,7 @@
 /**/admittance_controller:
   ros__parameters:
     robot_name: lbr
+    ft_sensor_name: estimated_wrench_interface # should equal the estimated_wrench_interface node name above
     admittance:
       mass: [0.05, 0.05, 0.05, 0.005, 0.005, 0.005]
       damping: [1., 1., 1., 0.1, 0.1, 0.1]

--- a/lbr_description/ros2_control/lbr_controllers.yaml
+++ b/lbr_description/ros2_control/lbr_controllers.yaml
@@ -130,7 +130,7 @@
       joint_gains: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0] # joint gains
       cartesian_gains: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0] # cartesian gains
     filter:
-      joint_velocity_tau: 0.4 # exponential moving average time constant for joint velocity commands [s]
+      f_ext_tau: 0.2 # exponential moving average time constant for external forces [s]
     on_activate:
       max_external_force: 0.0
       max_external_torque: 0.0

--- a/lbr_description/ros2_control/lbr_controllers.yaml
+++ b/lbr_description/ros2_control/lbr_controllers.yaml
@@ -113,6 +113,9 @@
       cartesian_gains: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0] # cartesian gains
     filter:
       joint_velocity_tau: 0.4 # exponential moving average time constant for joint velocity commands [s]
+    on_activate:
+      max_external_force: 0.0
+      max_external_torque: 0.0
 
 /**/twist_controller:
   ros__parameters:

--- a/lbr_description/ros2_control/lbr_system_config.yaml
+++ b/lbr_description/ros2_control/lbr_system_config.yaml
@@ -1,46 +1,32 @@
 # these parameters are read by the lbr_system_interface.xacro and configure the lbr_ros2_control::SystemInterface
-hardware:
-  fri_client_sdk: # the fri_client_sdk version is used to create the correct state interfaces lbr_system_interface.xacro
-    major_version: 1
-    minor_version: 15
-  client_command_mode: position # the command mode specifies the user-sent commands. Available: [position, torque, wrench]
-  port_id: 30200 # port id for the UDP communication. Useful in multi-robot setups
-  remote_host: INADDR_ANY # the expected robot IP address. INADDR_ANY will accept any incoming connection
-  rt_prio: 80 # real-time priority for the control loop
-  # exponential moving average time constant for joint position commands [s]:
-  #   set tau > robot sample time for more smoothing on the commands
-  #   set tau << robot sample time for no smoothing on the commands
-  joint_position_tau: 0.04
-  command_guard:
-    # if requested position / velocities beyond limits, CommandGuard will be triggered and the command will be overriden with the current state instead
-    # available: [default, safe_stop]
-    variant: default
-  state_guard:
-    # enable / disable the load data safety check in compliant control modes [CARTESIAN_IMPEDANCE, IMPEDANCE]
-    # in POSITION control mode, safety check is not performed
-    external_torque_safety_check: true
-    external_torque_limit: 2.0 # maximum allowed external joint torque on activation of compliant control modes [Nm]
-  # exponential moving average time constant for external joint torque measurements [s]:
-  #   set tau > robot sample time for more smoothing on the external torque measurements
-  #   set tau << robot sample time for no smoothing on the external torque measurements
-  external_torque_tau: 0.1
-  # exponential moving average time constant for joint torque measurements [s]:
-  #   set tau > robot sample time for more smoothing on the raw torque measurements
-  #   set tau << robot sample time for no smoothing on the raw torque measurements
-  measured_torque_tau: 0.1
-  # for position control, LBR works best in open_loop control mode
-  # note that open_loop is overridden to false if LBR is in impedance or Cartesian impedance control mode
-  open_loop: true
-estimated_ft_sensor: # estimates the external force-torque from the external joint torque values
-  enabled: true # whether to enable the force-torque estimation
-  update_rate: 100 # update rate for the force-torque estimation [Hz] (less or equal to controller manager update rate)
-  rt_prio: 30 # real-time priority for the force-torque estimation
-  chain_root: lbr_link_0
-  chain_tip: lbr_link_ee
-  damping: 0.2 # damping factor for the pseudo-inverse of the Jacobian
-  force_x_th: 2.0 # x-force threshold. Only if the force exceeds this value, the force will be considered
-  force_y_th: 2.0 # y-force threshold. Only if the force exceeds this value, the force will be considered
-  force_z_th: 2.0 # z-force threshold. Only if the force exceeds this value, the force will be considered
-  torque_x_th: 0.5 # x-torque threshold. Only if the torque exceeds this value, the torque will be considered
-  torque_y_th: 0.5 # y-torque threshold. Only if the torque exceeds this value, the torque will be considered
-  torque_z_th: 0.5 # z-torque threshold. Only if the torque exceeds this value, the torque will be considered
+fri_client_sdk: # the fri_client_sdk version is used to create the correct state interfaces lbr_system_interface.xacro
+  major_version: 1
+  minor_version: 15
+client_command_mode: position # the command mode specifies the user-sent commands. Available: [position, torque, wrench]
+port_id: 30200 # port id for the UDP communication. Useful in multi-robot setups
+remote_host: INADDR_ANY # the expected robot IP address. INADDR_ANY will accept any incoming connection
+rt_prio: 80 # real-time priority for the control loop
+# exponential moving average time constant for joint position commands [s]:
+#   set tau > robot sample time for more smoothing on the commands
+#   set tau << robot sample time for no smoothing on the commands
+joint_position_tau: 0.04
+command_guard:
+  # if requested position / velocities beyond limits, CommandGuard will be triggered and the command will be overriden with the current state instead
+  # available: [default, safe_stop]
+  variant: default
+state_guard:
+  # enable / disable the load data safety check in compliant control modes [CARTESIAN_IMPEDANCE, IMPEDANCE]
+  # in POSITION control mode, safety check is not performed
+  external_torque_safety_check: true
+  external_torque_limit: 2.0 # maximum allowed external joint torque on activation of compliant control modes [Nm]
+# exponential moving average time constant for external joint torque measurements [s]:
+#   set tau > robot sample time for more smoothing on the external torque measurements
+#   set tau << robot sample time for no smoothing on the external torque measurements
+external_torque_tau: 0.1
+# exponential moving average time constant for joint torque measurements [s]:
+#   set tau > robot sample time for more smoothing on the raw torque measurements
+#   set tau << robot sample time for no smoothing on the raw torque measurements
+measured_torque_tau: 0.1
+# for position control, LBR works best in open_loop control mode
+# note that open_loop is overridden to false if LBR is in impedance or Cartesian impedance control mode
+open_loop: true

--- a/lbr_description/ros2_control/lbr_system_config.yaml
+++ b/lbr_description/ros2_control/lbr_system_config.yaml
@@ -22,11 +22,11 @@ state_guard:
 # exponential moving average time constant for external joint torque measurements [s]:
 #   set tau > robot sample time for more smoothing on the external torque measurements
 #   set tau << robot sample time for no smoothing on the external torque measurements
-external_torque_tau: 0.1
+external_torque_tau: 0.01
 # exponential moving average time constant for joint torque measurements [s]:
 #   set tau > robot sample time for more smoothing on the raw torque measurements
 #   set tau << robot sample time for no smoothing on the raw torque measurements
-measured_torque_tau: 0.1
+measured_torque_tau: 0.01
 # for position control, LBR works best in open_loop control mode
 # note that open_loop is overridden to false if LBR is in impedance or Cartesian impedance control mode
 open_loop: true

--- a/lbr_description/ros2_control/lbr_system_interface.xacro
+++ b/lbr_description/ros2_control/lbr_system_interface.xacro
@@ -25,19 +25,19 @@
             <xacro:if value="${mode == 'hardware'}">
                 <hardware>
                     <plugin>lbr_ros2_control::SystemInterface</plugin>
-                    <param name="fri_client_sdk_major_version">${system_config['hardware']['fri_client_sdk']['major_version']}</param>
-                    <param name="fri_client_sdk_minor_version">${system_config['hardware']['fri_client_sdk']['minor_version']}</param>
-                    <param name="client_command_mode">${system_config['hardware']['client_command_mode']}</param>
-                    <param name="port_id">${system_config['hardware']['port_id']}</param>
-                    <param name="remote_host">${system_config['hardware']['remote_host']}</param>
-                    <param name="rt_prio">${system_config['hardware']['rt_prio']}</param>
-                    <param name="joint_position_tau">${system_config['hardware']['joint_position_tau']}</param>
-                    <param name="command_guard_variant">${system_config['hardware']['command_guard']['variant']}</param>
-                    <param name="state_guard_external_torque_safety_check">${system_config['hardware']['state_guard']['external_torque_safety_check']}</param>
-                    <param name="state_guard_external_torque_limit">${system_config['hardware']['state_guard']['external_torque_limit']}</param>
-                    <param name="external_torque_tau">${system_config['hardware']['external_torque_tau']}</param>
-                    <param name="measured_torque_tau">${system_config['hardware']['measured_torque_tau']}</param>
-                    <param name="open_loop">${system_config['hardware']['open_loop']}</param>
+                    <param name="fri_client_sdk_major_version">${system_config['fri_client_sdk']['major_version']}</param>
+                    <param name="fri_client_sdk_minor_version">${system_config['fri_client_sdk']['minor_version']}</param>
+                    <param name="client_command_mode">${system_config['client_command_mode']}</param>
+                    <param name="port_id">${system_config['port_id']}</param>
+                    <param name="remote_host">${system_config['remote_host']}</param>
+                    <param name="rt_prio">${system_config['rt_prio']}</param>
+                    <param name="joint_position_tau">${system_config['joint_position_tau']}</param>
+                    <param name="command_guard_variant">${system_config['command_guard']['variant']}</param>
+                    <param name="state_guard_external_torque_safety_check">${system_config['state_guard']['external_torque_safety_check']}</param>
+                    <param name="state_guard_external_torque_limit">${system_config['state_guard']['external_torque_limit']}</param>
+                    <param name="external_torque_tau">${system_config['external_torque_tau']}</param>
+                    <param name="measured_torque_tau">${system_config['measured_torque_tau']}</param>
+                    <param name="open_loop">${system_config['open_loop']}</param>
                 </hardware>
             </xacro:if>
 
@@ -58,30 +58,6 @@
                     <state_interface name="time_stamp_sec" />
                     <state_interface name="time_stamp_nano_sec" />
                     <state_interface name="tracking_performance" />
-                </sensor>
-
-                <sensor
-                    name="estimated_ft_sensor">
-                    <param name="enabled">${system_config['estimated_ft_sensor']['enabled']}</param>
-                    <param name="update_rate">${system_config['estimated_ft_sensor']['update_rate']}</param>
-                    <param name="rt_prio">${system_config['estimated_ft_sensor']['rt_prio']}</param>
-                    <param name="chain_root">${system_config['estimated_ft_sensor']['chain_root']}</param>
-                    <param name="chain_tip">${system_config['estimated_ft_sensor']['chain_tip']}</param>
-                    <param name="damping">${system_config['estimated_ft_sensor']['damping']}</param>
-                    <param name="force_x_th">${system_config['estimated_ft_sensor']['force_x_th']}</param>
-                    <param name="force_y_th">${system_config['estimated_ft_sensor']['force_y_th']}</param>
-                    <param name="force_z_th">${system_config['estimated_ft_sensor']['force_z_th']}</param>
-                    <param name="torque_x_th">${system_config['estimated_ft_sensor']['torque_x_th']}</param>
-                    <param name="torque_y_th">${system_config['estimated_ft_sensor']['torque_y_th']}</param>
-                    <param name="torque_z_th">${system_config['estimated_ft_sensor']['torque_z_th']}</param>
-                    <xacro:if value="${system_config['estimated_ft_sensor']['enabled']}">
-                        <state_interface name="force.x" />
-                        <state_interface name="force.y" />
-                        <state_interface name="force.z" />
-                        <state_interface name="torque.x" />
-                        <state_interface name="torque.y" />
-                        <state_interface name="torque.z" />
-                    </xacro:if>
                 </sensor>
 
                 <!-- FRI Cartesian impedance control mode -->
@@ -123,7 +99,7 @@
                         <param name="max_velocity">${max_velocity}</param>
                         <param name="max_torque">${max_torque}</param>
                         <xacro:if
-                            value="${system_config['hardware']['fri_client_sdk']['major_version'] == 1}">
+                            value="${system_config['fri_client_sdk']['major_version'] == 1}">
                             <state_interface name="commanded_joint_position" />
                         </xacro:if>
                         <state_interface name="commanded_torque" />

--- a/lbr_fri_ros2/CMakeLists.txt
+++ b/lbr_fri_ros2/CMakeLists.txt
@@ -36,10 +36,10 @@ add_library(lbr_fri_ros2
     src/async_client.cpp
     src/control.cpp
     src/filters.cpp
-    src/ft_estimator.cpp
     src/kinematics.cpp
     src/math.cpp
     src/worker.cpp
+    src/wrench_estimator.cpp
 )
 
 target_include_directories(lbr_fri_ros2

--- a/lbr_fri_ros2/include/lbr_fri_ros2/ft_estimator.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/ft_estimator.hpp
@@ -6,20 +6,12 @@
 #include <cmath>
 #include <memory>
 #include <string>
-#include <thread>
 
 #include "eigen3/Eigen/Core"
-#include "rclcpp/logger.hpp"
-#include "rclcpp/logging.hpp"
-#include "rclcpp/utilities.hpp"
 
-#include "friLBRState.h"
-
-#include "lbr_fri_idl/msg/lbr_state.hpp"
 #include "lbr_fri_ros2/kinematics.hpp"
 #include "lbr_fri_ros2/pinv.hpp"
 #include "lbr_fri_ros2/types.hpp"
-#include "lbr_fri_ros2/worker.hpp"
 
 namespace lbr_fri_ros2 {
 class FTEstimatorImpl {
@@ -29,9 +21,6 @@ class FTEstimatorImpl {
    * estimated force-torque.
    *
    */
-protected:
-  static constexpr char LOGGER_NAME[] = "lbr_fri_ros2::FTEstimatorImpl";
-
 public:
   FTEstimatorImpl(const std::string &robot_description,
                   const std::string &chain_root = "lbr_link_0",
@@ -69,24 +58,6 @@ protected:
   Eigen::Matrix<double, N_JNTS, CARTESIAN_DOF> jacobian_inv_;
   Eigen::Matrix<double, N_JNTS, 1> tau_ext_;
   Eigen::Matrix<double, CARTESIAN_DOF, 1> f_ext_raw_, f_ext_, f_ext_tf_;
-};
-
-class FTEstimator : public Worker {
-  /**
-   * @brief A simple class to run the FTEstimatorImpl asynchronously at a specified update rate.
-   *
-   */
-public:
-  FTEstimator(const std::shared_ptr<FTEstimatorImpl> ft_estimator,
-              const std::uint16_t &update_rate = 100);
-
-  inline std::string LOGGER_NAME() const override { return "lbr_fri_ros2::FTEstimator"; };
-
-protected:
-  void perform_work_() override;
-
-  std::shared_ptr<FTEstimatorImpl> ft_estimator_impl_ptr_;
-  std::uint16_t update_rate_;
 };
 } // namespace lbr_fri_ros2
 #endif // LBR_FRI_ROS2__FT_ESTIMATOR_HPP_

--- a/lbr_fri_ros2/include/lbr_fri_ros2/wrench_estimator.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/wrench_estimator.hpp
@@ -8,6 +8,8 @@
 #include <string>
 
 #include "eigen3/Eigen/Core"
+#include "rclcpp/logger.hpp"
+#include "rclcpp/logging.hpp"
 
 #include "lbr_fri_ros2/kinematics.hpp"
 #include "lbr_fri_ros2/pinv.hpp"
@@ -39,6 +41,9 @@ class WrenchEstimator {
    * estimated force-torque.
    *
    */
+protected:
+  static constexpr char LOGGER_NAME[] = "lbr_fri_ros2::WrenchEstimator";
+
 public:
   WrenchEstimator() = delete;
   WrenchEstimator(const std::string &robot_description,
@@ -56,6 +61,8 @@ public:
     tau_ext_ = Eigen::Map<const Eigen::Matrix<double, N_JNTS, 1>>(tau_ext.data());
   }
   inline void set_q(const_jnt_array_t_ref q) { q_ = q; }
+
+  void log_info() const;
 
 protected:
   // force threshold

--- a/lbr_fri_ros2/include/lbr_fri_ros2/wrench_estimator.hpp
+++ b/lbr_fri_ros2/include/lbr_fri_ros2/wrench_estimator.hpp
@@ -1,5 +1,5 @@
-#ifndef LBR_FRI_ROS2__FT_ESTIMATOR_HPP_
-#define LBR_FRI_ROS2__FT_ESTIMATOR_HPP_
+#ifndef LBR_FRI_ROS2__WRENCH_ESTIMATOR_HPP_
+#define LBR_FRI_ROS2__WRENCH_ESTIMATOR_HPP_
 
 #include <algorithm>
 #include <array>
@@ -14,19 +14,35 @@
 #include "lbr_fri_ros2/types.hpp"
 
 namespace lbr_fri_ros2 {
-class FTEstimatorImpl {
+struct WrenchEstimatorParameters {
+  std::string chain_root{"lbr_link_0"};
+  std::string chain_tip{"lbr_link_ee"};
+  double damping{0.2};
+  double force_x_th{2.0};
+  double force_y_th{2.0};
+  double force_z_th{2.0};
+  double torque_x_th{0.5};
+  double torque_y_th{0.5};
+  double torque_z_th{0.5};
+
+  bool valid() const {
+    return !(chain_root.empty() || chain_tip.empty() || damping < 0.0 || force_x_th < 0.0 ||
+             force_y_th < 0.0 || force_z_th < 0.0 || torque_x_th < 0.0 || torque_y_th < 0.0 ||
+             torque_z_th < 0.0);
+  }
+};
+
+class WrenchEstimator {
   /**
-   * @brief A class to estimate force-torques from external joint torque readings. Note that only
+   * @brief A class to estimate wrenches from external joint torque readings. Note that only
    * forces beyond a specified threshold are returned. The specified threshold is removed from the
    * estimated force-torque.
    *
    */
 public:
-  FTEstimatorImpl(const std::string &robot_description,
-                  const std::string &chain_root = "lbr_link_0",
-                  const std::string &chain_tip = "lbr_link_ee",
-                  const_cart_array_t_ref f_ext_th = {2., 2., 2., 0.5, 0.5, 0.5},
-                  const double &damping = 0.2);
+  WrenchEstimator() = delete;
+  WrenchEstimator(const std::string &robot_description,
+                  const WrenchEstimatorParameters &parameters = WrenchEstimatorParameters());
   void compute();
   void reset();
 
@@ -60,4 +76,4 @@ protected:
   Eigen::Matrix<double, CARTESIAN_DOF, 1> f_ext_raw_, f_ext_, f_ext_tf_;
 };
 } // namespace lbr_fri_ros2
-#endif // LBR_FRI_ROS2__FT_ESTIMATOR_HPP_
+#endif // LBR_FRI_ROS2__WRENCH_ESTIMATOR_HPP_

--- a/lbr_fri_ros2/package.xml
+++ b/lbr_fri_ros2/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_fri_ros2</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>The lbr_fri_ros2 package provides the Fast Robot Interface (FRI) integration into ROS
     2. Robot states can be extracted and commanded.</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>

--- a/lbr_fri_ros2/src/ft_estimator.cpp
+++ b/lbr_fri_ros2/src/ft_estimator.cpp
@@ -37,18 +37,4 @@ void FTEstimatorImpl::reset() {
   f_ext_tf_.setZero();
   jacobian_inv_.setZero();
 }
-
-FTEstimator::FTEstimator(const std::shared_ptr<FTEstimatorImpl> ft_estimator_impl_ptr,
-                         const std::uint16_t &update_rate)
-    : ft_estimator_impl_ptr_(ft_estimator_impl_ptr), update_rate_(update_rate) {}
-
-void FTEstimator::perform_work_() {
-  running_ = true;
-  while (rclcpp::ok() && !should_stop_) {
-    auto start = std::chrono::high_resolution_clock::now();
-    ft_estimator_impl_ptr_->compute();
-    std::this_thread::sleep_until(start + std::chrono::nanoseconds(static_cast<int>(
-                                              1.e9 / static_cast<double>(update_rate_))));
-  }
-};
 } // namespace lbr_fri_ros2

--- a/lbr_fri_ros2/src/interfaces/position_command.cpp
+++ b/lbr_fri_ros2/src/interfaces/position_command.cpp
@@ -12,7 +12,7 @@ void PositionCommandInterface::buffered_command_to_fri(fri_command_t_ref command
 #if FRI_CLIENT_VERSION_MAJOR == 1
   if (state.client_command_mode != KUKA::FRI::EClientCommandMode::POSITION) {
     std::string err =
-        "Client side (configured via hardware.client_command_mode in lbr_system_config.yaml) "
+        "Client side (configured via client_command_mode in lbr_system_config.yaml) "
         "expected robot in '" +
         EnumMaps::client_command_mode_map(KUKA::FRI::EClientCommandMode::POSITION) +
         "' command mode, but robot was in '" +
@@ -28,7 +28,7 @@ void PositionCommandInterface::buffered_command_to_fri(fri_command_t_ref command
 #if FRI_CLIENT_VERSION_MAJOR >= 2
   if (state.client_command_mode != KUKA::FRI::EClientCommandMode::JOINT_POSITION) {
     std::string err =
-        "Client side (configured via hardware.client_command_mode in lbr_system_config.yaml) "
+        "Client side (configured via client_command_mode in lbr_system_config.yaml) "
         "expected robot in '" +
         EnumMaps::client_command_mode_map(KUKA::FRI::EClientCommandMode::JOINT_POSITION) +
         " command mode, but robot was in '" +

--- a/lbr_fri_ros2/src/interfaces/torque_command.cpp
+++ b/lbr_fri_ros2/src/interfaces/torque_command.cpp
@@ -11,7 +11,7 @@ void TorqueCommandInterface::buffered_command_to_fri(fri_command_t_ref command,
   std::lock_guard<std::mutex> lock(command_mutex_);
   if (state.client_command_mode != KUKA::FRI::EClientCommandMode::TORQUE) {
     std::string err =
-        "Client side (configured via hardware.client_command_mode in lbr_system_config.yaml) "
+        "Client side (configured via client_command_mode in lbr_system_config.yaml) "
         "expected robot in '" +
         EnumMaps::client_command_mode_map(KUKA::FRI::EClientCommandMode::TORQUE) +
         "' command mode, but robot was in '" +

--- a/lbr_fri_ros2/src/interfaces/wrench_command.cpp
+++ b/lbr_fri_ros2/src/interfaces/wrench_command.cpp
@@ -11,7 +11,7 @@ void WrenchCommandInterface::buffered_command_to_fri(fri_command_t_ref command,
   std::lock_guard<std::mutex> lock(command_mutex_);
   if (state.client_command_mode != KUKA::FRI::EClientCommandMode::WRENCH) {
     std::string err =
-        "Client side (configured via hardware.client_command_mode in lbr_system_config.yaml) "
+        "Client side (configured via client_command_mode in lbr_system_config.yaml) "
         "expected robot in '" +
         EnumMaps::client_command_mode_map(KUKA::FRI::EClientCommandMode::WRENCH) +
         "' command mode, but robot was in '" +

--- a/lbr_fri_ros2/src/wrench_estimator.cpp
+++ b/lbr_fri_ros2/src/wrench_estimator.cpp
@@ -1,15 +1,24 @@
-#include "lbr_fri_ros2/ft_estimator.hpp"
+#include "lbr_fri_ros2/wrench_estimator.hpp"
 
 namespace lbr_fri_ros2 {
-FTEstimatorImpl::FTEstimatorImpl(const std::string &robot_description,
-                                 const std::string &chain_root, const std::string &chain_tip,
-                                 const_cart_array_t_ref f_ext_th, const double &damping)
-    : f_ext_th_(f_ext_th), damping_(damping) {
-  kinematics_ptr_ = std::make_unique<Kinematics>(robot_description, chain_root, chain_tip);
+WrenchEstimator::WrenchEstimator(const std::string &robot_description,
+                                 const WrenchEstimatorParameters &parameters) {
+  if (!parameters.valid()) {
+    throw std::invalid_argument("Invalid wrench estimator parameters.");
+  }
+  f_ext_th_[0] = parameters.force_x_th;
+  f_ext_th_[1] = parameters.force_y_th;
+  f_ext_th_[2] = parameters.force_z_th;
+  f_ext_th_[3] = parameters.torque_x_th;
+  f_ext_th_[4] = parameters.torque_y_th;
+  f_ext_th_[5] = parameters.torque_z_th;
+  damping_ = parameters.damping;
+  kinematics_ptr_ =
+      std::make_unique<Kinematics>(robot_description, parameters.chain_root, parameters.chain_tip);
   reset();
 }
 
-void FTEstimatorImpl::compute() {
+void WrenchEstimator::compute() {
   auto jacobian = kinematics_ptr_->compute_jacobian(q_);
   jacobian_inv_ = pinv(jacobian.data, damping_);
   f_ext_raw_ = jacobian_inv_.transpose() * tau_ext_;
@@ -29,7 +38,7 @@ void FTEstimatorImpl::compute() {
   f_ext_tf_.bottomRows(3) = Eigen::Matrix3d::Map(chain_tip_frame.M.data) * f_ext_.bottomRows(3);
 }
 
-void FTEstimatorImpl::reset() {
+void WrenchEstimator::reset() {
   std::fill(q_.begin(), q_.end(), 0.0);
   tau_ext_.setZero();
   f_ext_raw_.setZero();

--- a/lbr_fri_ros2/src/wrench_estimator.cpp
+++ b/lbr_fri_ros2/src/wrench_estimator.cpp
@@ -46,4 +46,13 @@ void WrenchEstimator::reset() {
   f_ext_tf_.setZero();
   jacobian_inv_.setZero();
 }
+
+void WrenchEstimator::log_info() const {
+  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME), "*** Parameters:");
+  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME), "*   Damping: %.3f", damping_);
+  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME), "*   Force thresholds: [%.3f, %.3f, %.3f]",
+              f_ext_th_[0], f_ext_th_[1], f_ext_th_[2]);
+  RCLCPP_INFO(rclcpp::get_logger(LOGGER_NAME), "*   Torque thresholds: [%.3f, %.3f, %.3f]",
+              f_ext_th_[3], f_ext_th_[4], f_ext_th_[5]);
+}
 } // namespace lbr_fri_ros2

--- a/lbr_fri_ros2_stack/package.xml
+++ b/lbr_fri_ros2_stack/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_fri_ros2_stack</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>ROS 2 stack for KUKA LBRs.</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
   <license>Apache-2.0</license>

--- a/lbr_ros2_control/CMakeLists.txt
+++ b/lbr_ros2_control/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(
   ${PROJECT_NAME}
   SHARED
   src/controllers/admittance_controller.cpp
-  src/controllers/estimated_wrench_broadcaster.cpp
+  src/controllers/estimated_wrench_interface.cpp
   src/controllers/lbr_joint_position_command_controller.cpp
   src/controllers/lbr_torque_command_controller.cpp
   src/controllers/lbr_wrench_command_controller.cpp

--- a/lbr_ros2_control/CMakeLists.txt
+++ b/lbr_ros2_control/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(controller_interface REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3)
 find_package(FRIClient REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(kinematics_interface REQUIRED)
 find_package(lbr_fri_idl REQUIRED)
@@ -32,6 +33,7 @@ add_library(
   ${PROJECT_NAME}
   SHARED
   src/controllers/admittance_controller.cpp
+  src/controllers/estimated_wrench_broadcaster.cpp
   src/controllers/lbr_joint_position_command_controller.cpp
   src/controllers/lbr_torque_command_controller.cpp
   src/controllers/lbr_wrench_command_controller.cpp
@@ -54,6 +56,7 @@ target_include_directories(
 set(AMENT_DEPENDENCIES
   controller_interface
   Eigen3
+  geometry_msgs
   hardware_interface
   kinematics_interface
   lbr_fri_idl

--- a/lbr_ros2_control/include/lbr_ros2_control/controllers/admittance_controller.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/controllers/admittance_controller.hpp
@@ -55,11 +55,17 @@ protected:
   void configure_admittance_impl_();
   void configure_inv_jac_ctrl_impl_();
   void configure_filters_();
+  void configure_safety_checks_();
   void zero_all_values_();
   void init_filters_with_update_rate_();
   bool any_external_force_torques_on_horizon_(
+      const double &max_external_force = 0., const double &max_external_torque = 0.,
       const std::chrono::milliseconds &horizon = std::chrono::milliseconds(200)) const;
   void log_info_() const;
+
+  // safety checks
+  double max_external_force_on_activate_{0.};
+  double max_external_torque_on_activate_{0.};
 
   // admittance
   bool initialized_ = false;

--- a/lbr_ros2_control/include/lbr_ros2_control/controllers/admittance_controller.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/controllers/admittance_controller.hpp
@@ -72,16 +72,17 @@ protected:
   std::unique_ptr<lbr_fri_ros2::AdmittanceImpl> admittance_impl_ptr_;
   Eigen::Matrix<double, 3, 1> t_init_, t_, t_prev_; // translation
   Eigen::Quaterniond r_init_, r_, r_prev_;          // rotation
-  Eigen::Matrix<double, lbr_fri_ros2::CARTESIAN_DOF, 1> f_ext_, delta_x_, dx_, ddx_;
+  Eigen::Matrix<double, lbr_fri_ros2::CARTESIAN_DOF, 1> f_ext_, f_ext_filtered_, delta_x_, dx_,
+      ddx_;
+
+  // external force smoothing
+  std::unique_ptr<lbr_fri_ros2::ExponentialFilterArray<lbr_fri_ros2::CARTESIAN_DOF>>
+      f_ext_filter_ptr_;
 
   // joint veloctiy computation
   std::unique_ptr<lbr_fri_ros2::InvJacCtrlImpl> inv_jac_ctrl_impl_ptr_;
   lbr_fri_ros2::jnt_array_t q_, dq_;
   Eigen::Matrix<double, lbr_fri_ros2::CARTESIAN_DOF, 1> twist_command_;
-
-  // velocity command smoothing
-  lbr_fri_ros2::jnt_array_t dq_filtered_;
-  std::unique_ptr<lbr_fri_ros2::ExponentialFilterArray<lbr_fri_ros2::N_JNTS>> dq_filter_ptr_;
 
   // interfaces
   lbr_fri_ros2::jnt_name_array_t joint_names_;

--- a/lbr_ros2_control/include/lbr_ros2_control/controllers/admittance_controller.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/controllers/admittance_controller.hpp
@@ -89,6 +89,7 @@ protected:
       joint_position_state_interfaces_;
   std::unique_ptr<std::reference_wrapper<hardware_interface::LoanedStateInterface>>
       session_state_interface_ptr_;
+  std::string ft_sensor_name_;
   std::unique_ptr<semantic_components::ForceTorqueSensor> estimated_ft_sensor_ptr_;
 };
 } // namespace lbr_ros2_control

--- a/lbr_ros2_control/include/lbr_ros2_control/controllers/estimated_wrench_broadcaster.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/controllers/estimated_wrench_broadcaster.hpp
@@ -1,0 +1,81 @@
+#ifndef LBR_ROS2_CONTROL__ESTIMATED_WRENCH_BROADCASTER_HPP_
+#define LBR_ROS2_CONTROL__ESTIMATED_WRENCH_BROADCASTER_HPP_
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "controller_interface/chainable_controller_interface.hpp"
+#include "geometry_msgs/msg/wrench_stamped.hpp"
+#include "hardware_interface/loaned_state_interface.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "realtime_tools/realtime_publisher.hpp"
+
+#include "lbr_fri_ros2/formatting.hpp"
+#include "lbr_fri_ros2/types.hpp"
+#include "lbr_fri_ros2/wrench_estimator.hpp"
+#include "lbr_ros2_control/system_interface_type_values.hpp"
+
+namespace lbr_ros2_control {
+class EstimatedWrenchBroadcaster : public controller_interface::ChainableControllerInterface {
+public:
+  EstimatedWrenchBroadcaster();
+
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  controller_interface::CallbackReturn on_init() override;
+
+protected:
+  std::vector<hardware_interface::StateInterface> on_export_state_interfaces() override;
+  std::vector<hardware_interface::CommandInterface> on_export_reference_interfaces() override;
+  bool on_set_chained_mode(bool chained_mode) override;
+
+  controller_interface::return_type
+  update_reference_from_subscribers(const rclcpp::Time &time,
+                                    const rclcpp::Duration &period) override;
+
+  controller_interface::return_type
+  update_and_write_commands(const rclcpp::Time &time, const rclcpp::Duration &period) override;
+
+  controller_interface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State &previous_state) override;
+
+  controller_interface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State &previous_state) override;
+
+  controller_interface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State &previous_state) override;
+
+protected:
+  bool assign_state_interfaces_();
+  void release_state_interfaces_();
+  void configure_joint_names_();
+  void configure_parameters_();
+  bool read_state_interfaces_();
+
+  // force-torque estimation
+  lbr_fri_ros2::WrenchEstimatorParameters wrench_estimator_parameters_;
+  std::unique_ptr<lbr_fri_ros2::WrenchEstimator> wrench_estimator_ptr_;
+  lbr_fri_ros2::cart_array_t wrench_; // zero or fill with nans?
+
+  // joint names
+  lbr_fri_ros2::jnt_name_array_t joint_names_;
+
+  // referenced by state interfaces
+  lbr_fri_ros2::jnt_array_t joint_positions_, external_torques_; // fill with nans...
+
+  // state interfaces (used by this controller to estimate wrenches)
+  std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>>
+      joint_position_state_interfaces_, external_torque_state_interfaces_;
+
+  // force-torque publisher (in unchained mode)
+  rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>::SharedPtr wrench_publisher_ptr_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::WrenchStamped>>
+      rt_wrench_publisher_ptr_;
+};
+} // namespace lbr_ros2_control
+#endif // LBR_ROS2_CONTROL__ESTIMATED_WRENCH_BROADCASTER_HPP_

--- a/lbr_ros2_control/include/lbr_ros2_control/controllers/estimated_wrench_interface.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/controllers/estimated_wrench_interface.hpp
@@ -55,10 +55,11 @@ protected:
   void configure_joint_names_();
   void configure_parameters_();
   bool read_state_interfaces_();
-  bool valid_states_();
+  bool valid_states_() const;
   void nan_wrench_();
   void nan_referenced_states_();
   void estimate_wrench_();
+  void log_info_() const;
 
   // force-torque estimation
   lbr_fri_ros2::WrenchEstimatorParameters wrench_estimator_parameters_;

--- a/lbr_ros2_control/include/lbr_ros2_control/controllers/estimated_wrench_interface.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/controllers/estimated_wrench_interface.hpp
@@ -1,17 +1,16 @@
-#ifndef LBR_ROS2_CONTROL__ESTIMATED_WRENCH_BROADCASTER_HPP_
-#define LBR_ROS2_CONTROL__ESTIMATED_WRENCH_BROADCASTER_HPP_
+#ifndef LBR_ROS2_CONTROL__ESTIMATED_WRENCH_INTERFACE_HPP_
+#define LBR_ROS2_CONTROL__ESTIMATED_WRENCH_INTERFACE_HPP_
 
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include "controller_interface/chainable_controller_interface.hpp"
-#include "geometry_msgs/msg/wrench_stamped.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "realtime_tools/realtime_publisher.hpp"
 
 #include "lbr_fri_ros2/formatting.hpp"
 #include "lbr_fri_ros2/types.hpp"
@@ -19,9 +18,9 @@
 #include "lbr_ros2_control/system_interface_type_values.hpp"
 
 namespace lbr_ros2_control {
-class EstimatedWrenchBroadcaster : public controller_interface::ChainableControllerInterface {
+class EstimatedWrenchInterface : public controller_interface::ChainableControllerInterface {
 public:
-  EstimatedWrenchBroadcaster();
+  EstimatedWrenchInterface();
 
   controller_interface::InterfaceConfiguration command_interface_configuration() const override;
 
@@ -56,26 +55,25 @@ protected:
   void configure_joint_names_();
   void configure_parameters_();
   bool read_state_interfaces_();
+  bool valid_states_();
+  void nan_wrench_();
+  void nan_referenced_states_();
+  void estimate_wrench_();
 
   // force-torque estimation
   lbr_fri_ros2::WrenchEstimatorParameters wrench_estimator_parameters_;
   std::unique_ptr<lbr_fri_ros2::WrenchEstimator> wrench_estimator_ptr_;
-  lbr_fri_ros2::cart_array_t wrench_; // zero or fill with nans?
+  lbr_fri_ros2::cart_array_t wrench_;
 
   // joint names
   lbr_fri_ros2::jnt_name_array_t joint_names_;
 
   // referenced by state interfaces
-  lbr_fri_ros2::jnt_array_t joint_positions_, external_torques_; // fill with nans...
+  lbr_fri_ros2::jnt_array_t joint_positions_, external_torques_;
 
   // state interfaces (used by this controller to estimate wrenches)
   std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>>
       joint_position_state_interfaces_, external_torque_state_interfaces_;
-
-  // force-torque publisher (in unchained mode)
-  rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>::SharedPtr wrench_publisher_ptr_;
-  std::shared_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::WrenchStamped>>
-      rt_wrench_publisher_ptr_;
 };
 } // namespace lbr_ros2_control
-#endif // LBR_ROS2_CONTROL__ESTIMATED_WRENCH_BROADCASTER_HPP_
+#endif // LBR_ROS2_CONTROL__ESTIMATED_WRENCH_INTERFACE_HPP_

--- a/lbr_ros2_control/include/lbr_ros2_control/controllers/lbr_state_broadcaster.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/controllers/lbr_state_broadcaster.hpp
@@ -54,6 +54,7 @@ protected:
   lbr_fri_ros2::jnt_name_array_t joint_names_;
   std::unordered_map<std::string, std::unordered_map<std::string, double>> state_interface_map_;
 
+  lbr_fri_idl::msg::LBRState lbr_state_;
   rclcpp::Publisher<lbr_fri_idl::msg::LBRState>::SharedPtr state_publisher_ptr_;
   std::shared_ptr<realtime_tools::RealtimePublisher<lbr_fri_idl::msg::LBRState>>
       rt_state_publisher_ptr_;

--- a/lbr_ros2_control/include/lbr_ros2_control/controllers/lbr_wrench_command_controller.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/controllers/lbr_wrench_command_controller.hpp
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "controller_interface/chainable_controller_interface.hpp"
-#include "controller_interface/controller_interface.hpp"
 #include "geometry_msgs/msg/wrench.hpp"
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
@@ -47,12 +46,12 @@ protected:
   std::vector<hardware_interface::CommandInterface> on_export_reference_interfaces() override;
   bool on_set_chained_mode(bool chained_mode) override;
 
-  // expect full lbr_wrench command in this mode....
+  // expect full lbr_wrench command in this mode
   controller_interface::return_type
   update_reference_from_subscribers(const rclcpp::Time &time,
                                     const rclcpp::Duration &period) override;
 
-  // expect just wrench command in this mode....
+  // expect just wrench command in this mode
   controller_interface::return_type
   update_and_write_commands(const rclcpp::Time &time, const rclcpp::Duration &period) override;
 
@@ -91,7 +90,7 @@ protected:
   lbr_fri_ros2::jnt_array_t joint_position_states_;
   lbr_fri_ros2::jnt_array_t joint_velocity_states_;
 
-  // state interfaces, consider access to external force interface for safety checking....
+  // state interfaces
   std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>>
       joint_position_state_interfaces_, joint_velocity_state_interfaces_;
 

--- a/lbr_ros2_control/include/lbr_ros2_control/controllers/lbr_wrench_command_controller.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/controllers/lbr_wrench_command_controller.hpp
@@ -100,12 +100,12 @@ protected:
 
   // in external mode, wrench and joint position are commanded
   realtime_tools::RealtimeBuffer<lbr_fri_idl::msg::LBRWrenchCommand::SharedPtr>
-      rt_lbr_wrench_command_ptr_;
+      lbr_wrench_command_rt_buffer_;
   rclcpp::Subscription<lbr_fri_idl::msg::LBRWrenchCommand>::SharedPtr
       lbr_wrench_command_subscription_ptr_;
 
   // in chained mode, only wrench is commanded
-  realtime_tools::RealtimeBuffer<geometry_msgs::msg::Wrench::SharedPtr> rt_wrench_command_ptr_;
+  realtime_tools::RealtimeBuffer<geometry_msgs::msg::Wrench::SharedPtr> wrench_command_rt_buffer_;
   rclcpp::Subscription<geometry_msgs::msg::Wrench>::SharedPtr wrench_command_subscription_ptr_;
 };
 } // namespace lbr_ros2_control

--- a/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
@@ -33,7 +33,7 @@
 namespace lbr_ros2_control {
 class SystemInterface : public hardware_interface::SystemInterface {
 protected:
-  struct SystemInterfaceParameters {
+  struct Parameters {
     uint8_t fri_client_sdk_major_version{1};
     uint8_t fri_client_sdk_minor_version{15};
 #if FRI_CLIENT_VERSION_MAJOR == 1
@@ -167,7 +167,7 @@ protected:
                                const KUKA::FRI::ESessionState &session_state);
 
   // robot parameters
-  SystemInterfaceParameters parameters_;
+  Parameters parameters_;
 
   // robot driver
   std::shared_ptr<lbr_fri_ros2::AsyncClient> async_client_ptr_;

--- a/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp
@@ -24,7 +24,6 @@
 #include "lbr_fri_ros2/app.hpp"
 #include "lbr_fri_ros2/async_client.hpp"
 #include "lbr_fri_ros2/formatting.hpp"
-#include "lbr_fri_ros2/ft_estimator.hpp"
 #include "lbr_fri_ros2/guards/command_guard.hpp"
 #include "lbr_fri_ros2/guards/state_guard.hpp"
 #include "lbr_fri_ros2/interfaces/state.hpp"
@@ -56,21 +55,6 @@ protected:
     bool open_loop{true};
   };
 
-  struct EstimatedFTSensorParameters {
-    bool enabled{true};
-    std::uint16_t update_rate{100};
-    int32_t rt_prio{30};
-    std::string chain_root{"lbr_link_0"};
-    std::string chain_tip{"lbr_link_ee"};
-    double damping{0.2};
-    double force_x_th{2.0};
-    double force_y_th{2.0};
-    double force_z_th{2.0};
-    double torque_x_th{0.5};
-    double torque_y_th{0.5};
-    double torque_z_th{0.5};
-  };
-
   struct CommandKeys {
     lbr_fri_ros2::jnt_name_array_t joint_position, torque;
     lbr_fri_ros2::cart_name_array_t wrench;
@@ -99,7 +83,6 @@ protected:
     std::string sample_time, session_state, connection_quality, safety_state, operation_mode,
         drive_state, client_command_mode, overlay_type, control_mode, time_stamp_sec,
         time_stamp_nano_sec, tracking_performance;
-    lbr_fri_ros2::cart_name_array_t estimated_ft;
 
     void populate_keys(const hardware_interface::HardwareInfo &info) {
       for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
@@ -127,13 +110,6 @@ protected:
       time_stamp_sec = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_SEC;
       time_stamp_nano_sec = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TIME_STAMP_NANO_SEC;
       tracking_performance = std::string(HW_IF_AUXILIARY_PREFIX) + "/" + HW_IF_TRACKING_PERFORMANCE;
-
-      estimated_ft[0] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_X;
-      estimated_ft[1] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Y;
-      estimated_ft[2] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Z;
-      estimated_ft[3] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_X;
-      estimated_ft[4] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Y;
-      estimated_ft[5] = std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Z;
     }
   };
 
@@ -145,9 +121,8 @@ protected:
   static constexpr uint8_t LBR_FRI_STATE_INTERFACE_SIZE = 6;
 #endif
   static constexpr uint8_t LBR_FRI_COMMAND_INTERFACE_SIZE = 2;
-  static constexpr uint8_t LBR_FRI_SENSORS = 2;
+  static constexpr uint8_t LBR_FRI_SENSORS = 1;
   static constexpr uint8_t AUXILIARY_SENSOR_SIZE = 12;
-  static constexpr uint8_t ESTIMATED_FT_SENSOR_SIZE = 6;
   static constexpr uint8_t GPIO_SIZE = 1;
 
 public:
@@ -178,7 +153,6 @@ public:
 protected:
   // setup
   bool parse_parameters_();
-  bool parse_ft_parameters_();
   void nan_command_interfaces_();
   void nan_state_interfaces_();
   bool verify_number_of_joints_();
@@ -186,7 +160,6 @@ protected:
   bool verify_joint_state_interfaces_();
   bool verify_sensors_();
   bool verify_auxiliary_sensor_();
-  bool verify_estimated_ft_sensor_();
   bool verify_gpios_();
 
   // monitor end of commanding active
@@ -195,7 +168,6 @@ protected:
 
   // robot parameters
   SystemInterfaceParameters parameters_;
-  EstimatedFTSensorParameters ft_parameters_;
 
   // robot driver
   std::shared_ptr<lbr_fri_ros2::AsyncClient> async_client_ptr_;
@@ -212,11 +184,6 @@ protected:
   void nan_last_states_();
   void update_last_states_();
   void compute_velocity_();
-
-  // additional force-torque state interface
-  lbr_fri_ros2::cart_array_t ft_;
-  std::shared_ptr<lbr_fri_ros2::FTEstimatorImpl> ft_estimator_impl_ptr_;
-  std::unique_ptr<lbr_fri_ros2::FTEstimator> ft_estimator_ptr_;
 
   // command and state buffers
   lbr_fri_idl::msg::LBRCommand lbr_command_;

--- a/lbr_ros2_control/include/lbr_ros2_control/system_interface_type_values.hpp
+++ b/lbr_ros2_control/include/lbr_ros2_control/system_interface_type_values.hpp
@@ -37,6 +37,5 @@ constexpr char HW_IF_TORQUE_Z[] = "torque.z";
 // additional LBR command interfaces, reference KUKA::FRI::LBRCommand
 constexpr char HW_IF_WRENCH_PREFIX[] = "wrench";
 constexpr char HW_IF_AUXILIARY_PREFIX[] = "auxiliary_sensor";
-constexpr char HW_IF_ESTIMATED_FT_PREFIX[] = "estimated_ft_sensor";
 } // namespace lbr_ros2_control
 #endif // LBR_ROS2_CONTROL__SYSTEM_INTERFACE_TYPE_VALUES_HPP_

--- a/lbr_ros2_control/package.xml
+++ b/lbr_ros2_control/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lbr_ros2_control</name>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <description>ROS 2 hardware hardware_interface for KUKA LBR through Fast Robot Interface (FRI).</description>
   <maintainer email="m.huber_1994@hotmail.de">mhubii</maintainer>
   <license>Apache-2.0</license>

--- a/lbr_ros2_control/package.xml
+++ b/lbr_ros2_control/package.xml
@@ -12,8 +12,11 @@
 
   <build_depend>eigen</build_depend>
 
+  <depend>controller_interface</depend>
   <depend>fri_client_sdk</depend>
   <depend>geometry_msgs</depend>
+  <depend>hardware_interface</depend>
+  <depend>kinematics_interface</depend>
   <depend>lbr_fri_idl</depend>
   <depend>lbr_fri_ros2</depend>
   <depend>pluginlib</depend>

--- a/lbr_ros2_control/plugin_description_files/controllers.xml
+++ b/lbr_ros2_control/plugin_description_files/controllers.xml
@@ -7,12 +7,12 @@
         <description>A simple admittance controller.</description>
     </class>
 
-    <!-- Estimated wrench broadcaster plugin -->
-    <class name="lbr_ros2_control/EstimatedWrenchBroadcaster"
-        type="lbr_ros2_control::EstimatedWrenchBroadcaster"
+    <!-- Estimated wrench interface plugin -->
+    <class name="lbr_ros2_control/EstimatedWrenchInterface"
+        type="lbr_ros2_control::EstimatedWrenchInterface"
         base_class_type="controller_interface::ChainableControllerInterface">
-        <description>Broadcast or chain the estimated external wrenches using the external
-            joint torques.</description>
+        <description>Estimates external wrenches using the external joint torques and exposes them
+            as interface.</description>
     </class>
 
     <!-- LBR forward position command controller plugin -->

--- a/lbr_ros2_control/plugin_description_files/controllers.xml
+++ b/lbr_ros2_control/plugin_description_files/controllers.xml
@@ -7,6 +7,14 @@
         <description>A simple admittance controller.</description>
     </class>
 
+    <!-- Estimated wrench broadcaster plugin -->
+    <class name="lbr_ros2_control/EstimatedWrenchBroadcaster"
+        type="lbr_ros2_control::EstimatedWrenchBroadcaster"
+        base_class_type="controller_interface::ChainableControllerInterface">
+        <description>Broadcast or chain the estimated external wrenches using the external
+            joint torques.</description>
+    </class>
+
     <!-- LBR forward position command controller plugin -->
     <class name="lbr_ros2_control/LBRJointPositionCommandController"
         type="lbr_ros2_control::LBRJointPositionCommandController"

--- a/lbr_ros2_control/src/controllers/admittance_controller.cpp
+++ b/lbr_ros2_control/src/controllers/admittance_controller.cpp
@@ -53,10 +53,13 @@ controller_interface::CallbackReturn AdmittanceController::on_init() {
     this->get_node()->declare_parameter("inv_jac_ctrl.cartesian_gains",
                                         std::vector<double>(lbr_fri_ros2::CARTESIAN_DOF, 0.0));
     this->get_node()->declare_parameter("filter.joint_velocity_tau", 0.4);
+    this->get_node()->declare_parameter("on_activate.max_external_force", 0.0);
+    this->get_node()->declare_parameter("on_activate.max_external_torque", 0.0);
     configure_joint_names_();
     configure_admittance_impl_();
     configure_inv_jac_ctrl_impl_();
     configure_filters_();
+    configure_safety_checks_();
     log_info_();
   } catch (const std::exception &e) {
     RCLCPP_ERROR(this->get_node()->get_logger(),
@@ -192,7 +195,8 @@ AdmittanceController::on_activate(const rclcpp_lifecycle::State & /*previous_sta
   init_filters_with_update_rate_();
   zero_all_values_();
   try {
-    if (any_external_force_torques_on_horizon_()) {
+    if (any_external_force_torques_on_horizon_(max_external_force_on_activate_,
+                                               max_external_torque_on_activate_)) {
       RCLCPP_ERROR_STREAM(
           this->get_node()->get_logger(),
           lbr_fri_ros2::ColorScheme::ERROR
@@ -373,6 +377,29 @@ void AdmittanceController::configure_filters_() {
       joint_velocity_tau);
 }
 
+void AdmittanceController::configure_safety_checks_() {
+  max_external_force_on_activate_ =
+      this->get_node()->get_parameter("on_activate.max_external_force").as_double();
+  max_external_torque_on_activate_ =
+      this->get_node()->get_parameter("on_activate.max_external_torque").as_double();
+  if (max_external_force_on_activate_ < 0.0) {
+    RCLCPP_WARN_STREAM(
+        this->get_node()->get_logger(),
+        lbr_fri_ros2::ColorScheme::WARNING
+            << "Parameter 'on_activate.max_external_force' is negative, overriding to 0.0."
+            << lbr_fri_ros2::ColorScheme::ENDC);
+    max_external_force_on_activate_ = 0.0;
+  }
+  if (max_external_torque_on_activate_ < 0.0) {
+    RCLCPP_WARN_STREAM(
+        this->get_node()->get_logger(),
+        lbr_fri_ros2::ColorScheme::WARNING
+            << "Parameter 'on_activate.max_external_torque' is negative, overriding to 0.0."
+            << lbr_fri_ros2::ColorScheme::ENDC);
+    max_external_torque_on_activate_ = 0.0;
+  }
+}
+
 void AdmittanceController::init_filters_with_update_rate_() {
   dq_filter_ptr_->initialize(1. / static_cast<double>(this->get_update_rate()));
 }
@@ -388,7 +415,15 @@ void AdmittanceController::zero_all_values_() {
 }
 
 bool AdmittanceController::any_external_force_torques_on_horizon_(
+    const double &max_external_force, const double &max_external_torque,
     const std::chrono::milliseconds &horizon) const {
+  if (max_external_force < 0.0 || max_external_torque < 0.0) {
+    RCLCPP_ERROR_STREAM(this->get_node()->get_logger(),
+                        lbr_fri_ros2::ColorScheme::ERROR
+                            << "Maximum external force-torque limits must be non-negative."
+                            << lbr_fri_ros2::ColorScheme::ENDC);
+    throw std::runtime_error("Invalid maximum external force-torque limits.");
+  }
   if (!estimated_ft_sensor_ptr_) {
     RCLCPP_ERROR(this->get_node()->get_logger(),
                  "Estimated force-torque sensor not initialized for external force-torque check.");
@@ -404,7 +439,8 @@ bool AdmittanceController::any_external_force_torques_on_horizon_(
   auto torques = this->estimated_ft_sensor_ptr_->get_torques();
   auto start_time = std::chrono::steady_clock::now();
   while (std::chrono::steady_clock::now() - start_time < horizon) {
-    if (!(lbr_fri_ros2::norm_in_bounds(forces, 0.) && lbr_fri_ros2::norm_in_bounds(torques, 0.))) {
+    if (!(lbr_fri_ros2::norm_in_bounds(forces, max_external_force) &&
+          lbr_fri_ros2::norm_in_bounds(torques, max_external_torque))) {
       RCLCPP_INFO_STREAM(this->get_node()->get_logger(),
                          "External force-torques detected: forces = ["
                              << forces[0] << ", " << forces[1] << ", " << forces[2]

--- a/lbr_ros2_control/src/controllers/admittance_controller.cpp
+++ b/lbr_ros2_control/src/controllers/admittance_controller.cpp
@@ -37,6 +37,7 @@ AdmittanceController::state_interface_configuration() const {
 controller_interface::CallbackReturn AdmittanceController::on_init() {
   try {
     this->get_node()->declare_parameter("robot_name", "lbr");
+    this->get_node()->declare_parameter("ft_sensor_name", "estimated_wrench_interface");
     this->get_node()->declare_parameter("admittance.mass",
                                         std::vector<double>(lbr_fri_ros2::CARTESIAN_DOF, 1.0));
     this->get_node()->declare_parameter("admittance.damping",
@@ -175,13 +176,11 @@ AdmittanceController::update(const rclcpp::Time & /*time*/, const rclcpp::Durati
 
 controller_interface::CallbackReturn
 AdmittanceController::on_configure(const rclcpp_lifecycle::State & /*previous_state*/) {
+  ft_sensor_name_ = this->get_node()->get_parameter("ft_sensor_name").as_string();
   estimated_ft_sensor_ptr_ = std::make_unique<semantic_components::ForceTorqueSensor>(
-      std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_X,
-      std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Y,
-      std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_FORCE_Z,
-      std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_X,
-      std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Y,
-      std::string(HW_IF_ESTIMATED_FT_PREFIX) + "/" + HW_IF_TORQUE_Z);
+      ft_sensor_name_ + "/" + HW_IF_FORCE_X, ft_sensor_name_ + "/" + HW_IF_FORCE_Y,
+      ft_sensor_name_ + "/" + HW_IF_FORCE_Z, ft_sensor_name_ + "/" + HW_IF_TORQUE_X,
+      ft_sensor_name_ + "/" + HW_IF_TORQUE_Y, ft_sensor_name_ + "/" + HW_IF_TORQUE_Z);
   return controller_interface::CallbackReturn::SUCCESS;
 }
 

--- a/lbr_ros2_control/src/controllers/admittance_controller.cpp
+++ b/lbr_ros2_control/src/controllers/admittance_controller.cpp
@@ -53,7 +53,7 @@ controller_interface::CallbackReturn AdmittanceController::on_init() {
                                         std::vector<double>(lbr_fri_ros2::N_JNTS, 0.0));
     this->get_node()->declare_parameter("inv_jac_ctrl.cartesian_gains",
                                         std::vector<double>(lbr_fri_ros2::CARTESIAN_DOF, 0.0));
-    this->get_node()->declare_parameter("filter.joint_velocity_tau", 0.4);
+    this->get_node()->declare_parameter("filter.f_ext_tau", 0.4);
     this->get_node()->declare_parameter("on_activate.max_external_force", 0.0);
     this->get_node()->declare_parameter("on_activate.max_external_torque", 0.0);
     configure_joint_names_();
@@ -131,8 +131,11 @@ AdmittanceController::update(const rclcpp::Time & /*time*/, const rclcpp::Durati
   f_ext_.head(3) = Eigen::Matrix3d::Map(chain_tip_frame.M.data).transpose() * f_ext_.head(3);
   f_ext_.tail(3) = Eigen::Matrix3d::Map(chain_tip_frame.M.data).transpose() * f_ext_.tail(3);
 
+  // filter the external forces
+  f_ext_filter_ptr_->compute(f_ext_.data(), f_ext_filtered_.data());
+
   // compute admittance
-  admittance_impl_ptr_->compute(f_ext_, delta_x_, dx_, ddx_);
+  admittance_impl_ptr_->compute(f_ext_filtered_, delta_x_, dx_, ddx_);
 
   // integrate ddx_ to command velocity
   dx_ += ddx_ * dt;
@@ -158,12 +161,9 @@ AdmittanceController::update(const rclcpp::Time & /*time*/, const rclcpp::Durati
   // compute the joint velocity from the twist command target
   inv_jac_ctrl_impl_ptr_->compute(twist_command_, q_, dq_);
 
-  // filter the joint velocities
-  dq_filter_ptr_->compute(dq_.data(), dq_filtered_.data());
-
   // pass joint positions to hardware
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
-    if (!this->command_interfaces_[i].set_value(q_[i] + dq_filtered_[i] * dt)) {
+    if (!this->command_interfaces_[i].set_value(q_[i] + dq_[i] * dt)) {
       RCLCPP_ERROR_STREAM(this->get_node()->get_logger(),
                           lbr_fri_ros2::ColorScheme::ERROR
                               << "Failed to set joint position for joint '" << joint_names_[i]
@@ -361,19 +361,18 @@ void AdmittanceController::configure_inv_jac_ctrl_impl_() {
 }
 
 void AdmittanceController::configure_filters_() {
-  auto joint_velocity_tau =
-      this->get_node()->get_parameter("filter.joint_velocity_tau").as_double();
-  if (joint_velocity_tau < 0.4) {
+  auto f_ext_tau = this->get_node()->get_parameter("filter.f_ext_tau").as_double();
+  if (f_ext_tau < 0.2) {
     RCLCPP_ERROR_STREAM(this->get_node()->get_logger(),
                         lbr_fri_ros2::ColorScheme::ERROR
-                            << "Joint velocity filter time constant too small ("
-                            << joint_velocity_tau
-                            << "s). Currently enforced to be at least 0.4s for proper smoothing."
+                            << "External force filter time constant too small (" << f_ext_tau
+                            << "s). Currently enforced to be at least 0.2s for proper smoothing."
                             << lbr_fri_ros2::ColorScheme::ENDC);
-    throw std::runtime_error("Invalid joint velocity filter time constant.");
+    throw std::runtime_error("Invalid external force filter time constant.");
   }
-  dq_filter_ptr_ = std::make_unique<lbr_fri_ros2::ExponentialFilterArray<lbr_fri_ros2::N_JNTS>>(
-      joint_velocity_tau);
+  f_ext_filter_ptr_ =
+      std::make_unique<lbr_fri_ros2::ExponentialFilterArray<lbr_fri_ros2::CARTESIAN_DOF>>(
+          f_ext_tau);
 }
 
 void AdmittanceController::configure_safety_checks_() {
@@ -400,16 +399,16 @@ void AdmittanceController::configure_safety_checks_() {
 }
 
 void AdmittanceController::init_filters_with_update_rate_() {
-  dq_filter_ptr_->initialize(1. / static_cast<double>(this->get_update_rate()));
+  f_ext_filter_ptr_->initialize(1. / static_cast<double>(this->get_update_rate()));
 }
 
 void AdmittanceController::zero_all_values_() {
   f_ext_.setZero();
+  f_ext_filtered_.setZero();
   delta_x_.setZero();
   dx_.setZero();
   ddx_.setZero();
   std::fill(dq_.begin(), dq_.end(), 0.0);
-  std::fill(dq_filtered_.begin(), dq_filtered_.end(), 0.0);
   twist_command_.setZero();
 }
 
@@ -456,7 +455,7 @@ bool AdmittanceController::any_external_force_torques_on_horizon_(
 void AdmittanceController::log_info_() const {
   admittance_impl_ptr_->log_info();
   inv_jac_ctrl_impl_ptr_->log_info();
-  dq_filter_ptr_->log_info();
+  f_ext_filter_ptr_->log_info();
 }
 } // namespace lbr_ros2_control
 

--- a/lbr_ros2_control/src/controllers/estimated_wrench_broadcaster.cpp
+++ b/lbr_ros2_control/src/controllers/estimated_wrench_broadcaster.cpp
@@ -1,0 +1,231 @@
+#include "lbr_ros2_control/controllers/estimated_wrench_broadcaster.hpp"
+
+namespace lbr_ros2_control {
+EstimatedWrenchBroadcaster::EstimatedWrenchBroadcaster() {}
+
+controller_interface::InterfaceConfiguration
+EstimatedWrenchBroadcaster::command_interface_configuration() const {
+  return controller_interface::InterfaceConfiguration{
+      controller_interface::interface_configuration_type::NONE};
+}
+
+controller_interface::InterfaceConfiguration
+EstimatedWrenchBroadcaster::state_interface_configuration() const {
+  controller_interface::InterfaceConfiguration interface_configuration;
+  interface_configuration.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+
+  // joint position and external torque interfaces
+  for (const auto &joint_name : joint_names_) {
+    interface_configuration.names.push_back(joint_name + "/" + hardware_interface::HW_IF_POSITION);
+    interface_configuration.names.push_back(joint_name + "/" + HW_IF_EXTERNAL_TORQUE);
+  }
+  return interface_configuration;
+}
+
+controller_interface::CallbackReturn EstimatedWrenchBroadcaster::on_init() {
+  try {
+    get_node()->declare_parameter("robot_name", "lbr");
+    get_node()->declare_parameter("wrench_estimator_parameters.chain_root", "lbr_link_0");
+    get_node()->declare_parameter("wrench_estimator_parameters.chain_tip", "lbr_link_ee");
+    get_node()->declare_parameter("wrench_estimator_parameters.damping", 0.2);
+    get_node()->declare_parameter("wrench_estimator_parameters.force_x_th", 2.0);
+    get_node()->declare_parameter("wrench_estimator_parameters.force_y_th", 2.0);
+    get_node()->declare_parameter("wrench_estimator_parameters.force_z_th", 2.0);
+    get_node()->declare_parameter("wrench_estimator_parameters.torque_x_th", 0.5);
+    get_node()->declare_parameter("wrench_estimator_parameters.torque_y_th", 0.5);
+    get_node()->declare_parameter("wrench_estimator_parameters.torque_z_th", 0.5);
+    configure_joint_names_();
+    configure_parameters_();
+    wrench_estimator_ptr_ = std::make_unique<lbr_fri_ros2::WrenchEstimator>(
+        get_robot_description(), wrench_estimator_parameters_);
+  } catch (const std::exception &e) {
+    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
+                        lbr_fri_ros2::ColorScheme::ERROR
+                            << "Failed to initialize estimated wrench broadcaster with: "
+                            << e.what() << "." << lbr_fri_ros2::ColorScheme::ENDC);
+    return controller_interface::CallbackReturn::ERROR;
+  }
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+std::vector<hardware_interface::StateInterface>
+EstimatedWrenchBroadcaster::on_export_state_interfaces() {
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+  state_interfaces.emplace_back(std::string(get_node()->get_name()), HW_IF_FORCE_X, &wrench_[0]);
+  state_interfaces.emplace_back(std::string(get_node()->get_name()), HW_IF_FORCE_Y, &wrench_[1]);
+  state_interfaces.emplace_back(std::string(get_node()->get_name()), HW_IF_FORCE_Z, &wrench_[2]);
+  state_interfaces.emplace_back(std::string(get_node()->get_name()), HW_IF_TORQUE_X, &wrench_[3]);
+  state_interfaces.emplace_back(std::string(get_node()->get_name()), HW_IF_TORQUE_Y, &wrench_[4]);
+  state_interfaces.emplace_back(std::string(get_node()->get_name()), HW_IF_TORQUE_Z, &wrench_[5]);
+  return state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface>
+EstimatedWrenchBroadcaster::on_export_reference_interfaces() {
+  return {};
+}
+
+bool EstimatedWrenchBroadcaster::on_set_chained_mode(bool chained_mode) {
+  RCLCPP_INFO(get_node()->get_logger(), "EstimatedWrenchBroadcaster::on_set_chained_mode");
+  if (chained_mode) {
+    // delete publisher
+  } else {
+    // create publisher
+  }
+  return true;
+} // in chained mode expose force-torque state interface, else publish...
+
+controller_interface::return_type
+EstimatedWrenchBroadcaster::update_reference_from_subscribers(const rclcpp::Time & /*time*/,
+                                                              const rclcpp::Duration & /*period*/) {
+  //   RCLCPP_INFO(get_node()->get_logger(),
+  //               "EstimatedWrenchBroadcaster::update_reference_from_subscribers");
+  return controller_interface::return_type::OK;
+} // do nothing...
+
+controller_interface::return_type
+EstimatedWrenchBroadcaster::update_and_write_commands(const rclcpp::Time & /*time*/,
+                                                      const rclcpp::Duration & /*period*/) {
+  // get joint positions
+  if (!read_state_interfaces_()) {
+    return controller_interface::return_type::OK;
+  }
+
+  //   RCLCPP_INFO(get_node()->get_logger(),
+  //   "EstimatedWrenchBroadcaster::update_and_write_commands");
+  wrench_estimator_ptr_->set_q(joint_positions_);
+  wrench_estimator_ptr_->set_tau_ext(external_torques_);
+  wrench_estimator_ptr_->compute();
+  wrench_estimator_ptr_->get_f_ext_tf(wrench_);
+  return controller_interface::return_type::OK;
+} // do nothing...
+
+controller_interface::CallbackReturn
+EstimatedWrenchBroadcaster::on_configure(const rclcpp_lifecycle::State & /*previous_state*/) {
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn
+EstimatedWrenchBroadcaster::on_activate(const rclcpp_lifecycle::State & /*previous_state*/) {
+  if (!assign_state_interfaces_()) {
+    release_state_interfaces_();
+    return controller_interface::CallbackReturn::ERROR;
+  }
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn
+EstimatedWrenchBroadcaster::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/) {
+  release_state_interfaces_();
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+bool EstimatedWrenchBroadcaster::assign_state_interfaces_() {
+  for (auto &state_interface : state_interfaces_) {
+    if (state_interface.get_interface_name() == hardware_interface::HW_IF_POSITION) {
+      joint_position_state_interfaces_.push_back(std::ref(state_interface));
+    }
+    if (state_interface.get_interface_name() == HW_IF_EXTERNAL_TORQUE) {
+      external_torque_state_interfaces_.push_back(std::ref(state_interface));
+    }
+  }
+  if (joint_position_state_interfaces_.size() != lbr_fri_ros2::N_JNTS) {
+    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
+                        lbr_fri_ros2::ColorScheme::ERROR
+                            << "Number of joint position state interfaces '"
+                            << joint_position_state_interfaces_.size()
+                            << "' does not match the number of joints "
+                               "in the robot '"
+                            << lbr_fri_ros2::N_JNTS << "'." << lbr_fri_ros2::ColorScheme::ENDC);
+    return false;
+  }
+  if (external_torque_state_interfaces_.size() != lbr_fri_ros2::N_JNTS) {
+    RCLCPP_ERROR_STREAM(get_node()->get_logger(), lbr_fri_ros2::ColorScheme::ERROR
+                                                      << "Number of external torque interfaces '"
+                                                      << external_torque_state_interfaces_.size()
+                                                      << "' does not match the number of joints "
+                                                         "in the robot '"
+                                                      << lbr_fri_ros2::N_JNTS << "'."
+                                                      << lbr_fri_ros2::ColorScheme::ENDC);
+    return false;
+  }
+  return true;
+}
+
+void EstimatedWrenchBroadcaster::release_state_interfaces_() {
+  joint_position_state_interfaces_.clear();
+  external_torque_state_interfaces_.clear();
+}
+
+void EstimatedWrenchBroadcaster::configure_joint_names_() {
+  if (joint_names_.size() != lbr_fri_ros2::N_JNTS) {
+    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
+                        lbr_fri_ros2::ColorScheme::ERROR
+                            << "Number of joint names '" << joint_names_.size()
+                            << "' does not match the number of joints in the robot '"
+                            << lbr_fri_ros2::N_JNTS << "'." << lbr_fri_ros2::ColorScheme::ENDC);
+    throw std::runtime_error("Failed to configure joint names.");
+  }
+  std::string robot_name = get_node()->get_parameter("robot_name").as_string();
+  for (int i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+    joint_names_[i] = robot_name + "_A" + std::to_string(i + 1);
+  }
+}
+
+void EstimatedWrenchBroadcaster::configure_parameters_() {
+  wrench_estimator_parameters_.chain_root =
+      get_node()->get_parameter("wrench_estimator_parameters.chain_root").as_string();
+  wrench_estimator_parameters_.chain_tip =
+      get_node()->get_parameter("wrench_estimator_parameters.chain_tip").as_string();
+  wrench_estimator_parameters_.damping =
+      get_node()->get_parameter("wrench_estimator_parameters.damping").as_double();
+  wrench_estimator_parameters_.force_x_th =
+      get_node()->get_parameter("wrench_estimator_parameters.force_x_th").as_double();
+  wrench_estimator_parameters_.force_y_th =
+      get_node()->get_parameter("wrench_estimator_parameters.force_y_th").as_double();
+  wrench_estimator_parameters_.force_z_th =
+      get_node()->get_parameter("wrench_estimator_parameters.force_z_th").as_double();
+  wrench_estimator_parameters_.torque_x_th =
+      get_node()->get_parameter("wrench_estimator_parameters.torque_x_th").as_double();
+  wrench_estimator_parameters_.torque_y_th =
+      get_node()->get_parameter("wrench_estimator_parameters.torque_y_th").as_double();
+  wrench_estimator_parameters_.torque_z_th =
+      get_node()->get_parameter("wrench_estimator_parameters.torque_z_th").as_double();
+  if (!wrench_estimator_parameters_.valid()) {
+    RCLCPP_ERROR_STREAM(get_node()->get_logger(), lbr_fri_ros2::ColorScheme::ERROR
+                                                      << "Invalid wrench estimator parameters."
+                                                      << lbr_fri_ros2::ColorScheme::ENDC);
+    throw std::runtime_error("Invalid wrench estimator parameters.");
+  }
+}
+
+bool EstimatedWrenchBroadcaster::read_state_interfaces_() {
+  for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+    auto q_i = joint_position_state_interfaces_[i].get().get_optional();
+    if (!q_i.has_value()) {
+      RCLCPP_WARN_STREAM(get_node()->get_logger(), lbr_fri_ros2::ColorScheme::WARNING
+                                                       << "Failed to get joint position for joint '"
+                                                       << joint_names_[i] << "'."
+                                                       << lbr_fri_ros2::ColorScheme::ENDC);
+      return false;
+    }
+    joint_positions_[i] = *q_i;
+
+    auto tau_ext_i = external_torque_state_interfaces_[i].get().get_optional();
+    if (!tau_ext_i.has_value()) {
+      RCLCPP_WARN_STREAM(get_node()->get_logger(),
+                         lbr_fri_ros2::ColorScheme::WARNING
+                             << "Failed to get external torque for joint '" << joint_names_[i]
+                             << "'." << lbr_fri_ros2::ColorScheme::ENDC);
+      return false;
+    }
+    external_torques_[i] = *tau_ext_i;
+  }
+  return true;
+}
+} // namespace lbr_ros2_control
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(lbr_ros2_control::EstimatedWrenchBroadcaster,
+                       controller_interface::ChainableControllerInterface)

--- a/lbr_ros2_control/src/controllers/estimated_wrench_interface.cpp
+++ b/lbr_ros2_control/src/controllers/estimated_wrench_interface.cpp
@@ -38,6 +38,7 @@ controller_interface::CallbackReturn EstimatedWrenchInterface::on_init() {
     configure_parameters_();
     wrench_estimator_ptr_ = std::make_unique<lbr_fri_ros2::WrenchEstimator>(
         get_robot_description(), wrench_estimator_parameters_);
+    log_info_();
   } catch (const std::exception &e) {
     RCLCPP_ERROR_STREAM(get_node()->get_logger(),
                         lbr_fri_ros2::ColorScheme::ERROR
@@ -221,7 +222,7 @@ bool EstimatedWrenchInterface::read_state_interfaces_() {
   return true;
 }
 
-bool EstimatedWrenchInterface::valid_states_() {
+bool EstimatedWrenchInterface::valid_states_() const {
   for (size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
     if (std::isnan(joint_positions_[i]) || std::isnan(external_torques_[i])) {
       return false;
@@ -245,6 +246,8 @@ void EstimatedWrenchInterface::estimate_wrench_() {
   wrench_estimator_ptr_->compute();
   wrench_estimator_ptr_->get_f_ext_tf(wrench_);
 }
+
+void EstimatedWrenchInterface::log_info_() const { wrench_estimator_ptr_->log_info(); }
 } // namespace lbr_ros2_control
 
 #include "pluginlib/class_list_macros.hpp"

--- a/lbr_ros2_control/src/controllers/estimated_wrench_interface.cpp
+++ b/lbr_ros2_control/src/controllers/estimated_wrench_interface.cpp
@@ -1,16 +1,16 @@
-#include "lbr_ros2_control/controllers/estimated_wrench_broadcaster.hpp"
+#include "lbr_ros2_control/controllers/estimated_wrench_interface.hpp"
 
 namespace lbr_ros2_control {
-EstimatedWrenchBroadcaster::EstimatedWrenchBroadcaster() {}
+EstimatedWrenchInterface::EstimatedWrenchInterface() {}
 
 controller_interface::InterfaceConfiguration
-EstimatedWrenchBroadcaster::command_interface_configuration() const {
+EstimatedWrenchInterface::command_interface_configuration() const {
   return controller_interface::InterfaceConfiguration{
       controller_interface::interface_configuration_type::NONE};
 }
 
 controller_interface::InterfaceConfiguration
-EstimatedWrenchBroadcaster::state_interface_configuration() const {
+EstimatedWrenchInterface::state_interface_configuration() const {
   controller_interface::InterfaceConfiguration interface_configuration;
   interface_configuration.type = controller_interface::interface_configuration_type::INDIVIDUAL;
 
@@ -22,18 +22,18 @@ EstimatedWrenchBroadcaster::state_interface_configuration() const {
   return interface_configuration;
 }
 
-controller_interface::CallbackReturn EstimatedWrenchBroadcaster::on_init() {
+controller_interface::CallbackReturn EstimatedWrenchInterface::on_init() {
   try {
     get_node()->declare_parameter("robot_name", "lbr");
-    get_node()->declare_parameter("wrench_estimator_parameters.chain_root", "lbr_link_0");
-    get_node()->declare_parameter("wrench_estimator_parameters.chain_tip", "lbr_link_ee");
-    get_node()->declare_parameter("wrench_estimator_parameters.damping", 0.2);
-    get_node()->declare_parameter("wrench_estimator_parameters.force_x_th", 2.0);
-    get_node()->declare_parameter("wrench_estimator_parameters.force_y_th", 2.0);
-    get_node()->declare_parameter("wrench_estimator_parameters.force_z_th", 2.0);
-    get_node()->declare_parameter("wrench_estimator_parameters.torque_x_th", 0.5);
-    get_node()->declare_parameter("wrench_estimator_parameters.torque_y_th", 0.5);
-    get_node()->declare_parameter("wrench_estimator_parameters.torque_z_th", 0.5);
+    get_node()->declare_parameter("wrench_estimator.chain_root", "lbr_link_0");
+    get_node()->declare_parameter("wrench_estimator.chain_tip", "lbr_link_ee");
+    get_node()->declare_parameter("wrench_estimator.damping", 0.2);
+    get_node()->declare_parameter("wrench_estimator.force_x_th", 2.0);
+    get_node()->declare_parameter("wrench_estimator.force_y_th", 2.0);
+    get_node()->declare_parameter("wrench_estimator.force_z_th", 2.0);
+    get_node()->declare_parameter("wrench_estimator.torque_x_th", 0.5);
+    get_node()->declare_parameter("wrench_estimator.torque_y_th", 0.5);
+    get_node()->declare_parameter("wrench_estimator.torque_z_th", 0.5);
     configure_joint_names_();
     configure_parameters_();
     wrench_estimator_ptr_ = std::make_unique<lbr_fri_ros2::WrenchEstimator>(
@@ -41,15 +41,15 @@ controller_interface::CallbackReturn EstimatedWrenchBroadcaster::on_init() {
   } catch (const std::exception &e) {
     RCLCPP_ERROR_STREAM(get_node()->get_logger(),
                         lbr_fri_ros2::ColorScheme::ERROR
-                            << "Failed to initialize estimated wrench broadcaster with: "
-                            << e.what() << "." << lbr_fri_ros2::ColorScheme::ENDC);
+                            << "Failed to initialize estimated wrench interface with: " << e.what()
+                            << "." << lbr_fri_ros2::ColorScheme::ENDC);
     return controller_interface::CallbackReturn::ERROR;
   }
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
 std::vector<hardware_interface::StateInterface>
-EstimatedWrenchBroadcaster::on_export_state_interfaces() {
+EstimatedWrenchInterface::on_export_state_interfaces() {
   std::vector<hardware_interface::StateInterface> state_interfaces;
   state_interfaces.emplace_back(std::string(get_node()->get_name()), HW_IF_FORCE_X, &wrench_[0]);
   state_interfaces.emplace_back(std::string(get_node()->get_name()), HW_IF_FORCE_Y, &wrench_[1]);
@@ -61,66 +61,63 @@ EstimatedWrenchBroadcaster::on_export_state_interfaces() {
 }
 
 std::vector<hardware_interface::CommandInterface>
-EstimatedWrenchBroadcaster::on_export_reference_interfaces() {
+EstimatedWrenchInterface::on_export_reference_interfaces() {
   return {};
 }
 
-bool EstimatedWrenchBroadcaster::on_set_chained_mode(bool chained_mode) {
-  RCLCPP_INFO(get_node()->get_logger(), "EstimatedWrenchBroadcaster::on_set_chained_mode");
-  if (chained_mode) {
-    // delete publisher
-  } else {
-    // create publisher
-  }
+bool EstimatedWrenchInterface::on_set_chained_mode(bool /*chained_mode*/) {
+  // broadcasters don't support chaining:
+  // https://github.com/ros-controls/ros2_controllers/issues/2052#issuecomment-3616731834
   return true;
-} // in chained mode expose force-torque state interface, else publish...
+}
 
 controller_interface::return_type
-EstimatedWrenchBroadcaster::update_reference_from_subscribers(const rclcpp::Time & /*time*/,
-                                                              const rclcpp::Duration & /*period*/) {
-  //   RCLCPP_INFO(get_node()->get_logger(),
-  //               "EstimatedWrenchBroadcaster::update_reference_from_subscribers");
+EstimatedWrenchInterface::update_reference_from_subscribers(const rclcpp::Time & /*time*/,
+                                                            const rclcpp::Duration & /*period*/) {
   return controller_interface::return_type::OK;
-} // do nothing...
+}
 
 controller_interface::return_type
-EstimatedWrenchBroadcaster::update_and_write_commands(const rclcpp::Time & /*time*/,
-                                                      const rclcpp::Duration & /*period*/) {
-  // get joint positions
+EstimatedWrenchInterface::update_and_write_commands(const rclcpp::Time & /*time*/,
+                                                    const rclcpp::Duration & /*period*/) {
+  // get joint positions and external torques
   if (!read_state_interfaces_()) {
     return controller_interface::return_type::OK;
   }
 
-  //   RCLCPP_INFO(get_node()->get_logger(),
-  //   "EstimatedWrenchBroadcaster::update_and_write_commands");
-  wrench_estimator_ptr_->set_q(joint_positions_);
-  wrench_estimator_ptr_->set_tau_ext(external_torques_);
-  wrench_estimator_ptr_->compute();
-  wrench_estimator_ptr_->get_f_ext_tf(wrench_);
+  // validate read states
+  if (!valid_states_()) {
+    return controller_interface::return_type::OK;
+  }
+
+  // estimate wrench given states
+  estimate_wrench_();
   return controller_interface::return_type::OK;
-} // do nothing...
+}
 
 controller_interface::CallbackReturn
-EstimatedWrenchBroadcaster::on_configure(const rclcpp_lifecycle::State & /*previous_state*/) {
+EstimatedWrenchInterface::on_configure(const rclcpp_lifecycle::State & /*previous_state*/) {
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::CallbackReturn
-EstimatedWrenchBroadcaster::on_activate(const rclcpp_lifecycle::State & /*previous_state*/) {
+EstimatedWrenchInterface::on_activate(const rclcpp_lifecycle::State & /*previous_state*/) {
   if (!assign_state_interfaces_()) {
     release_state_interfaces_();
     return controller_interface::CallbackReturn::ERROR;
   }
+  nan_wrench_();
+  nan_referenced_states_();
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::CallbackReturn
-EstimatedWrenchBroadcaster::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/) {
+EstimatedWrenchInterface::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/) {
   release_state_interfaces_();
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
-bool EstimatedWrenchBroadcaster::assign_state_interfaces_() {
+bool EstimatedWrenchInterface::assign_state_interfaces_() {
   for (auto &state_interface : state_interfaces_) {
     if (state_interface.get_interface_name() == hardware_interface::HW_IF_POSITION) {
       joint_position_state_interfaces_.push_back(std::ref(state_interface));
@@ -152,12 +149,12 @@ bool EstimatedWrenchBroadcaster::assign_state_interfaces_() {
   return true;
 }
 
-void EstimatedWrenchBroadcaster::release_state_interfaces_() {
+void EstimatedWrenchInterface::release_state_interfaces_() {
   joint_position_state_interfaces_.clear();
   external_torque_state_interfaces_.clear();
 }
 
-void EstimatedWrenchBroadcaster::configure_joint_names_() {
+void EstimatedWrenchInterface::configure_joint_names_() {
   if (joint_names_.size() != lbr_fri_ros2::N_JNTS) {
     RCLCPP_ERROR_STREAM(get_node()->get_logger(),
                         lbr_fri_ros2::ColorScheme::ERROR
@@ -172,25 +169,25 @@ void EstimatedWrenchBroadcaster::configure_joint_names_() {
   }
 }
 
-void EstimatedWrenchBroadcaster::configure_parameters_() {
+void EstimatedWrenchInterface::configure_parameters_() {
   wrench_estimator_parameters_.chain_root =
-      get_node()->get_parameter("wrench_estimator_parameters.chain_root").as_string();
+      get_node()->get_parameter("wrench_estimator.chain_root").as_string();
   wrench_estimator_parameters_.chain_tip =
-      get_node()->get_parameter("wrench_estimator_parameters.chain_tip").as_string();
+      get_node()->get_parameter("wrench_estimator.chain_tip").as_string();
   wrench_estimator_parameters_.damping =
-      get_node()->get_parameter("wrench_estimator_parameters.damping").as_double();
+      get_node()->get_parameter("wrench_estimator.damping").as_double();
   wrench_estimator_parameters_.force_x_th =
-      get_node()->get_parameter("wrench_estimator_parameters.force_x_th").as_double();
+      get_node()->get_parameter("wrench_estimator.force_x_th").as_double();
   wrench_estimator_parameters_.force_y_th =
-      get_node()->get_parameter("wrench_estimator_parameters.force_y_th").as_double();
+      get_node()->get_parameter("wrench_estimator.force_y_th").as_double();
   wrench_estimator_parameters_.force_z_th =
-      get_node()->get_parameter("wrench_estimator_parameters.force_z_th").as_double();
+      get_node()->get_parameter("wrench_estimator.force_z_th").as_double();
   wrench_estimator_parameters_.torque_x_th =
-      get_node()->get_parameter("wrench_estimator_parameters.torque_x_th").as_double();
+      get_node()->get_parameter("wrench_estimator.torque_x_th").as_double();
   wrench_estimator_parameters_.torque_y_th =
-      get_node()->get_parameter("wrench_estimator_parameters.torque_y_th").as_double();
+      get_node()->get_parameter("wrench_estimator.torque_y_th").as_double();
   wrench_estimator_parameters_.torque_z_th =
-      get_node()->get_parameter("wrench_estimator_parameters.torque_z_th").as_double();
+      get_node()->get_parameter("wrench_estimator.torque_z_th").as_double();
   if (!wrench_estimator_parameters_.valid()) {
     RCLCPP_ERROR_STREAM(get_node()->get_logger(), lbr_fri_ros2::ColorScheme::ERROR
                                                       << "Invalid wrench estimator parameters."
@@ -199,33 +196,58 @@ void EstimatedWrenchBroadcaster::configure_parameters_() {
   }
 }
 
-bool EstimatedWrenchBroadcaster::read_state_interfaces_() {
+bool EstimatedWrenchInterface::read_state_interfaces_() {
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
-    auto q_i = joint_position_state_interfaces_[i].get().get_optional();
-    if (!q_i.has_value()) {
+    auto joint_position = joint_position_state_interfaces_[i].get().get_optional();
+    if (!joint_position.has_value()) {
       RCLCPP_WARN_STREAM(get_node()->get_logger(), lbr_fri_ros2::ColorScheme::WARNING
                                                        << "Failed to get joint position for joint '"
                                                        << joint_names_[i] << "'."
                                                        << lbr_fri_ros2::ColorScheme::ENDC);
       return false;
     }
-    joint_positions_[i] = *q_i;
+    joint_positions_[i] = *joint_position;
 
-    auto tau_ext_i = external_torque_state_interfaces_[i].get().get_optional();
-    if (!tau_ext_i.has_value()) {
+    auto external_torque = external_torque_state_interfaces_[i].get().get_optional();
+    if (!external_torque.has_value()) {
       RCLCPP_WARN_STREAM(get_node()->get_logger(),
                          lbr_fri_ros2::ColorScheme::WARNING
                              << "Failed to get external torque for joint '" << joint_names_[i]
                              << "'." << lbr_fri_ros2::ColorScheme::ENDC);
       return false;
     }
-    external_torques_[i] = *tau_ext_i;
+    external_torques_[i] = *external_torque;
   }
   return true;
+}
+
+bool EstimatedWrenchInterface::valid_states_() {
+  for (size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
+    if (std::isnan(joint_positions_[i]) || std::isnan(external_torques_[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void EstimatedWrenchInterface::nan_wrench_() {
+  wrench_.fill(std::numeric_limits<double>::quiet_NaN());
+}
+
+void EstimatedWrenchInterface::nan_referenced_states_() {
+  joint_positions_.fill(std::numeric_limits<double>::quiet_NaN());
+  external_torques_.fill(std::numeric_limits<double>::quiet_NaN());
+}
+
+void EstimatedWrenchInterface::estimate_wrench_() {
+  wrench_estimator_ptr_->set_q(joint_positions_);
+  wrench_estimator_ptr_->set_tau_ext(external_torques_);
+  wrench_estimator_ptr_->compute();
+  wrench_estimator_ptr_->get_f_ext_tf(wrench_);
 }
 } // namespace lbr_ros2_control
 
 #include "pluginlib/class_list_macros.hpp"
 
-PLUGINLIB_EXPORT_CLASS(lbr_ros2_control::EstimatedWrenchBroadcaster,
+PLUGINLIB_EXPORT_CLASS(lbr_ros2_control::EstimatedWrenchInterface,
                        controller_interface::ChainableControllerInterface)

--- a/lbr_ros2_control/src/controllers/lbr_state_broadcaster.cpp
+++ b/lbr_ros2_control/src/controllers/lbr_state_broadcaster.cpp
@@ -53,63 +53,57 @@ controller_interface::return_type LBRStateBroadcaster::update(const rclcpp::Time
   if (std::isnan(state_interface_map_[joint_names_[0]][hardware_interface::HW_IF_POSITION])) {
     return controller_interface::return_type::OK;
   }
-  if (rt_state_publisher_ptr_->trylock()) {
-    // FRI related states
-    rt_state_publisher_ptr_->msg_.client_command_mode = static_cast<int8_t>(
-        state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_CLIENT_COMMAND_MODE]);
-    rt_state_publisher_ptr_->msg_.connection_quality =
-        static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_CONNECTION_QUALITY]);
-    rt_state_publisher_ptr_->msg_.control_mode =
-        static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_CONTROL_MODE]);
-    rt_state_publisher_ptr_->msg_.drive_state =
-        static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_DRIVE_STATE]);
-    rt_state_publisher_ptr_->msg_.operation_mode =
-        static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_OPERATION_MODE]);
-    rt_state_publisher_ptr_->msg_.overlay_type =
-        static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_OVERLAY_TYPE]);
-    rt_state_publisher_ptr_->msg_.safety_state =
-        static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_SAFETY_STATE]);
-    rt_state_publisher_ptr_->msg_.sample_time =
-        state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_SAMPLE_TIME];
-    rt_state_publisher_ptr_->msg_.session_state =
-        static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_SESSION_STATE]);
-    rt_state_publisher_ptr_->msg_.time_stamp_nano_sec = static_cast<uint32_t>(
-        state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_TIME_STAMP_NANO_SEC]);
-    rt_state_publisher_ptr_->msg_.time_stamp_sec =
-        static_cast<uint32_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_TIME_STAMP_SEC]);
-    rt_state_publisher_ptr_->msg_.tracking_performance =
-        state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_TRACKING_PERFORMANCE];
 
-    // joint related states
-    std::for_each(joint_names_.begin(), joint_names_.end(),
-                  [&, idx = 0](const std::string &joint_name) mutable {
+  // FRI related states
+  lbr_state_.client_command_mode =
+      static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_CLIENT_COMMAND_MODE]);
+  lbr_state_.connection_quality =
+      static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_CONNECTION_QUALITY]);
+  lbr_state_.control_mode =
+      static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_CONTROL_MODE]);
+  lbr_state_.drive_state =
+      static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_DRIVE_STATE]);
+  lbr_state_.operation_mode =
+      static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_OPERATION_MODE]);
+  lbr_state_.overlay_type =
+      static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_OVERLAY_TYPE]);
+  lbr_state_.safety_state =
+      static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_SAFETY_STATE]);
+  lbr_state_.sample_time = state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_SAMPLE_TIME];
+  lbr_state_.session_state =
+      static_cast<int8_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_SESSION_STATE]);
+  lbr_state_.time_stamp_nano_sec = static_cast<uint32_t>(
+      state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_TIME_STAMP_NANO_SEC]);
+  lbr_state_.time_stamp_sec =
+      static_cast<uint32_t>(state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_TIME_STAMP_SEC]);
+  lbr_state_.tracking_performance =
+      state_interface_map_[HW_IF_AUXILIARY_PREFIX][HW_IF_TRACKING_PERFORMANCE];
+
+  // joint related states
+  std::for_each(joint_names_.begin(), joint_names_.end(),
+                [&, idx = 0](const std::string &joint_name) mutable {
 #if FRI_CLIENT_VERSION_MAJOR == 1
-                    rt_state_publisher_ptr_->msg_.commanded_joint_position[idx] =
-                        state_interface_map_[joint_name][HW_IF_COMMANDED_JOINT_POSITION];
+                  lbr_state_.commanded_joint_position[idx] =
+                      state_interface_map_[joint_name][HW_IF_COMMANDED_JOINT_POSITION];
 #endif
-                    rt_state_publisher_ptr_->msg_.commanded_torque[idx] =
-                        state_interface_map_[joint_name][HW_IF_COMMANDED_TORQUE];
-                    rt_state_publisher_ptr_->msg_.external_torque[idx] =
-                        state_interface_map_[joint_name][HW_IF_EXTERNAL_TORQUE];
-                    if (rt_state_publisher_ptr_->msg_.session_state == KUKA::FRI::COMMANDING_WAIT ||
-                        rt_state_publisher_ptr_->msg_.session_state ==
-                            KUKA::FRI::COMMANDING_ACTIVE) {
-                      rt_state_publisher_ptr_->msg_.ipo_joint_position[idx] =
-                          state_interface_map_[joint_name][HW_IF_IPO_JOINT_POSITION];
-                    } else {
-                      rt_state_publisher_ptr_->msg_.ipo_joint_position[idx] =
-                          std::numeric_limits<double>::quiet_NaN();
-                    }
-                    rt_state_publisher_ptr_->msg_.measured_joint_position[idx] =
-                        state_interface_map_[joint_name][hardware_interface::HW_IF_POSITION];
-                    rt_state_publisher_ptr_->msg_.measured_torque[idx] =
-                        state_interface_map_[joint_name][hardware_interface::HW_IF_EFFORT];
-                    ++idx;
-                  });
-
-    rt_state_publisher_ptr_->unlockAndPublish();
-  }
-
+                  lbr_state_.commanded_torque[idx] =
+                      state_interface_map_[joint_name][HW_IF_COMMANDED_TORQUE];
+                  lbr_state_.external_torque[idx] =
+                      state_interface_map_[joint_name][HW_IF_EXTERNAL_TORQUE];
+                  if (lbr_state_.session_state == KUKA::FRI::COMMANDING_WAIT ||
+                      lbr_state_.session_state == KUKA::FRI::COMMANDING_ACTIVE) {
+                    lbr_state_.ipo_joint_position[idx] =
+                        state_interface_map_[joint_name][HW_IF_IPO_JOINT_POSITION];
+                  } else {
+                    lbr_state_.ipo_joint_position[idx] = std::numeric_limits<double>::quiet_NaN();
+                  }
+                  lbr_state_.measured_joint_position[idx] =
+                      state_interface_map_[joint_name][hardware_interface::HW_IF_POSITION];
+                  lbr_state_.measured_torque[idx] =
+                      state_interface_map_[joint_name][hardware_interface::HW_IF_EFFORT];
+                  ++idx;
+                });
+  rt_state_publisher_ptr_->try_publish(lbr_state_);
   return controller_interface::return_type::OK;
 }
 
@@ -138,27 +132,25 @@ void LBRStateBroadcaster::init_state_interface_map_() {
 }
 
 void LBRStateBroadcaster::init_state_msg_() {
-  rt_state_publisher_ptr_->msg_.client_command_mode = std::numeric_limits<int8_t>::quiet_NaN();
+  lbr_state_.client_command_mode = std::numeric_limits<int8_t>::quiet_NaN();
 #if FRI_CLIENT_VERSION_MAJOR == 1
-  rt_state_publisher_ptr_->msg_.commanded_joint_position.fill(
-      std::numeric_limits<double>::quiet_NaN());
+  lbr_state_.commanded_joint_position.fill(std::numeric_limits<double>::quiet_NaN());
 #endif
-  rt_state_publisher_ptr_->msg_.commanded_torque.fill(std::numeric_limits<double>::quiet_NaN());
-  rt_state_publisher_ptr_->msg_.connection_quality = std::numeric_limits<int8_t>::quiet_NaN();
-  rt_state_publisher_ptr_->msg_.control_mode = std::numeric_limits<int8_t>::quiet_NaN();
-  rt_state_publisher_ptr_->msg_.drive_state = std::numeric_limits<int8_t>::quiet_NaN();
-  rt_state_publisher_ptr_->msg_.external_torque.fill(std::numeric_limits<double>::quiet_NaN());
-  rt_state_publisher_ptr_->msg_.ipo_joint_position.fill(std::numeric_limits<double>::quiet_NaN());
-  rt_state_publisher_ptr_->msg_.measured_joint_position.fill(
-      std::numeric_limits<double>::quiet_NaN());
-  rt_state_publisher_ptr_->msg_.measured_torque.fill(std::numeric_limits<double>::quiet_NaN());
-  rt_state_publisher_ptr_->msg_.overlay_type = std::numeric_limits<int8_t>::quiet_NaN();
-  rt_state_publisher_ptr_->msg_.safety_state = std::numeric_limits<int8_t>::quiet_NaN();
-  rt_state_publisher_ptr_->msg_.sample_time = std::numeric_limits<double>::quiet_NaN();
-  rt_state_publisher_ptr_->msg_.session_state = std::numeric_limits<int8_t>::quiet_NaN();
-  rt_state_publisher_ptr_->msg_.time_stamp_nano_sec = std::numeric_limits<uint32_t>::quiet_NaN();
-  rt_state_publisher_ptr_->msg_.time_stamp_sec = std::numeric_limits<uint32_t>::quiet_NaN();
-  rt_state_publisher_ptr_->msg_.tracking_performance = std::numeric_limits<double>::quiet_NaN();
+  lbr_state_.commanded_torque.fill(std::numeric_limits<double>::quiet_NaN());
+  lbr_state_.connection_quality = std::numeric_limits<int8_t>::quiet_NaN();
+  lbr_state_.control_mode = std::numeric_limits<int8_t>::quiet_NaN();
+  lbr_state_.drive_state = std::numeric_limits<int8_t>::quiet_NaN();
+  lbr_state_.external_torque.fill(std::numeric_limits<double>::quiet_NaN());
+  lbr_state_.ipo_joint_position.fill(std::numeric_limits<double>::quiet_NaN());
+  lbr_state_.measured_joint_position.fill(std::numeric_limits<double>::quiet_NaN());
+  lbr_state_.measured_torque.fill(std::numeric_limits<double>::quiet_NaN());
+  lbr_state_.overlay_type = std::numeric_limits<int8_t>::quiet_NaN();
+  lbr_state_.safety_state = std::numeric_limits<int8_t>::quiet_NaN();
+  lbr_state_.sample_time = std::numeric_limits<double>::quiet_NaN();
+  lbr_state_.session_state = std::numeric_limits<int8_t>::quiet_NaN();
+  lbr_state_.time_stamp_nano_sec = std::numeric_limits<uint32_t>::quiet_NaN();
+  lbr_state_.time_stamp_sec = std::numeric_limits<uint32_t>::quiet_NaN();
+  lbr_state_.tracking_performance = std::numeric_limits<double>::quiet_NaN();
 }
 
 void LBRStateBroadcaster::configure_joint_names_() {

--- a/lbr_ros2_control/src/controllers/lbr_wrench_command_controller.cpp
+++ b/lbr_ros2_control/src/controllers/lbr_wrench_command_controller.cpp
@@ -2,8 +2,8 @@
 
 namespace lbr_ros2_control {
 LBRWrenchCommandController::LBRWrenchCommandController()
-    : rt_lbr_wrench_command_ptr_(nullptr), lbr_wrench_command_subscription_ptr_(nullptr),
-      rt_wrench_command_ptr_(nullptr), wrench_command_subscription_ptr_(nullptr) {}
+    : lbr_wrench_command_rt_buffer_(nullptr), lbr_wrench_command_subscription_ptr_(nullptr),
+      wrench_command_rt_buffer_(nullptr), wrench_command_subscription_ptr_(nullptr) {}
 
 controller_interface::InterfaceConfiguration
 LBRWrenchCommandController::command_interface_configuration() const {
@@ -98,7 +98,7 @@ bool LBRWrenchCommandController::on_set_chained_mode(bool chained_mode) {
 controller_interface::return_type
 LBRWrenchCommandController::update_reference_from_subscribers(const rclcpp::Time & /*time*/,
                                                               const rclcpp::Duration & /*period*/) {
-  auto lbr_wrench_command = rt_lbr_wrench_command_ptr_.readFromRT();
+  auto lbr_wrench_command = lbr_wrench_command_rt_buffer_.readFromRT();
   if (!lbr_wrench_command || !(*lbr_wrench_command)) {
     return controller_interface::return_type::OK;
   }
@@ -170,7 +170,7 @@ LBRWrenchCommandController::update_and_write_commands(const rclcpp::Time & /*tim
   }
 
   // read wrench command in chained mode
-  auto wrench_command = rt_wrench_command_ptr_.readFromRT();
+  auto wrench_command = wrench_command_rt_buffer_.readFromRT();
   if (!wrench_command || !(*wrench_command)) {
     if (!zero_wrench_commands_()) {
       return controller_interface::return_type::ERROR;
@@ -382,7 +382,7 @@ void LBRWrenchCommandController::init_lbr_wrench_command_subscription_() {
       this->get_node()->create_subscription<lbr_fri_idl::msg::LBRWrenchCommand>(
           "command/lbr_wrench_command", 1,
           [this](const lbr_fri_idl::msg::LBRWrenchCommand::SharedPtr msg) {
-            rt_lbr_wrench_command_ptr_.writeFromNonRT(msg);
+            lbr_wrench_command_rt_buffer_.writeFromNonRT(msg);
           });
 }
 
@@ -390,7 +390,7 @@ void LBRWrenchCommandController::init_wrench_command_subscription_() {
   wrench_command_subscription_ptr_ =
       this->get_node()->create_subscription<geometry_msgs::msg::Wrench>(
           "command/wrench", 1, [this](const geometry_msgs::msg::Wrench::SharedPtr msg) {
-            rt_wrench_command_ptr_.writeFromNonRT(msg);
+            wrench_command_rt_buffer_.writeFromNonRT(msg);
           });
 }
 

--- a/lbr_ros2_control/src/system_interface.cpp
+++ b/lbr_ros2_control/src/system_interface.cpp
@@ -56,25 +56,6 @@ SystemInterface::on_init(const hardware_interface::HardwareComponentInterfacePar
     return controller_interface::CallbackReturn::ERROR;
   }
 
-  // setup force-torque estimator
-  if (!parse_ft_parameters_()) {
-    return controller_interface::CallbackReturn::ERROR;
-  }
-  if (ft_parameters_.enabled) {
-    ft_estimator_impl_ptr_ = std::make_shared<lbr_fri_ros2::FTEstimatorImpl>(
-        info_.original_xml, ft_parameters_.chain_root, ft_parameters_.chain_tip,
-        lbr_fri_ros2::cart_array_t{
-            ft_parameters_.force_x_th,
-            ft_parameters_.force_y_th,
-            ft_parameters_.force_z_th,
-            ft_parameters_.torque_x_th,
-            ft_parameters_.torque_y_th,
-            ft_parameters_.torque_z_th,
-        });
-    ft_estimator_ptr_ = std::make_unique<lbr_fri_ros2::FTEstimator>(ft_estimator_impl_ptr_,
-                                                                    ft_parameters_.update_rate);
-  }
-
   // populate the keys
   command_keys_.populate_keys(info_);
   state_keys_.populate_keys(info_);
@@ -180,27 +161,12 @@ controller_interface::CallbackReturn SystemInterface::on_activate(const rclcpp_l
     }
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
-
-  // ft sensor
-  if (!ft_estimator_ptr_ && ft_parameters_.enabled) {
-    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                        lbr_fri_ros2::ColorScheme::ERROR
-                            << "Failed to instantiate FTEstimator despite user request."
-                            << lbr_fri_ros2::ColorScheme::ENDC);
-    return controller_interface::CallbackReturn::ERROR;
-  }
-  if (ft_estimator_ptr_) {
-    ft_estimator_ptr_->run_async(ft_parameters_.rt_prio);
-  }
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::CallbackReturn
 SystemInterface::on_deactivate(const rclcpp_lifecycle::State &) {
   app_ptr_->request_stop();
-  if (ft_estimator_ptr_) {
-    ft_estimator_ptr_->request_stop();
-  }
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
@@ -235,7 +201,6 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
                             << lbr_fri_ros2::ColorScheme::ENDC);
     app_ptr_->request_stop();
     app_ptr_->close_udp_socket();
-    ft_estimator_ptr_->request_stop();
     return hardware_interface::return_type::ERROR;
   }
 
@@ -271,18 +236,6 @@ hardware_interface::return_type SystemInterface::read(const rclcpp::Time & /*tim
   // additional velocity state interface
   compute_velocity_();
   update_last_states_();
-
-  // additional force-torque state interface
-  if (ft_parameters_.enabled) {
-    // note that (if enabled) the computation is performed asynchronously to not block the main
-    // thread
-    ft_estimator_impl_ptr_->set_q(lbr_state_.measured_joint_position);
-    ft_estimator_impl_ptr_->set_tau_ext(lbr_state_.external_torque);
-    ft_estimator_impl_ptr_->get_f_ext_tf(ft_);
-    for (std::size_t i = 0; i < lbr_fri_ros2::CARTESIAN_DOF; ++i) {
-      set_state(state_keys_.estimated_ft[i], ft_[i]);
-    }
-  }
   return hardware_interface::return_type::OK;
 }
 
@@ -385,35 +338,6 @@ bool SystemInterface::parse_parameters_() {
   return true;
 }
 
-bool SystemInterface::parse_ft_parameters_() {
-  try {
-    std::transform(info_.sensors[1].parameters.at("enabled").begin(),
-                   info_.sensors[1].parameters.at("enabled").end(),
-                   info_.sensors[1].parameters.at("enabled").begin(),
-                   ::tolower); // convert to lower case
-    const auto &estimated_ft_sensor = info_.sensors[1];
-    ft_parameters_.enabled = estimated_ft_sensor.parameters.at("enabled") == "true";
-    ft_parameters_.update_rate = std::stoul(estimated_ft_sensor.parameters.at("update_rate"));
-    ft_parameters_.rt_prio = std::stoi(estimated_ft_sensor.parameters.at("rt_prio"));
-    ft_parameters_.chain_root = estimated_ft_sensor.parameters.at("chain_root");
-    ft_parameters_.chain_tip = estimated_ft_sensor.parameters.at("chain_tip");
-    ft_parameters_.damping = std::stod(estimated_ft_sensor.parameters.at("damping"));
-    ft_parameters_.force_x_th = std::stod(estimated_ft_sensor.parameters.at("force_x_th"));
-    ft_parameters_.force_y_th = std::stod(estimated_ft_sensor.parameters.at("force_y_th"));
-    ft_parameters_.force_z_th = std::stod(estimated_ft_sensor.parameters.at("force_z_th"));
-    ft_parameters_.torque_x_th = std::stod(estimated_ft_sensor.parameters.at("torque_x_th"));
-    ft_parameters_.torque_y_th = std::stod(estimated_ft_sensor.parameters.at("torque_y_th"));
-    ft_parameters_.torque_z_th = std::stod(estimated_ft_sensor.parameters.at("torque_z_th"));
-  } catch (const std::out_of_range &e) {
-    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                        lbr_fri_ros2::ColorScheme::ERROR
-                            << "Failed to parse force-torque sensor parameters with: " << e.what()
-                            << lbr_fri_ros2::ColorScheme::ENDC);
-    return false;
-  }
-  return true;
-}
-
 void SystemInterface::nan_command_interfaces_() {
   for (std::size_t i = 0; i < lbr_fri_ros2::N_JNTS; ++i) {
     set_command(command_keys_.joint_position[i], std::numeric_limits<double>::quiet_NaN());
@@ -456,9 +380,6 @@ void SystemInterface::nan_state_interfaces_() {
 
   // additional velocity state interface
   velocity_.fill(std::numeric_limits<double>::quiet_NaN());
-
-  // additional force-torque state interface
-  ft_.fill(std::numeric_limits<double>::quiet_NaN());
 }
 
 bool SystemInterface::verify_number_of_joints_() {
@@ -550,11 +471,6 @@ bool SystemInterface::verify_sensors_() {
   if (!verify_auxiliary_sensor_()) {
     return false;
   }
-  if (ft_parameters_.enabled) {
-    if (!verify_estimated_ft_sensor_()) {
-      return false;
-    }
-  }
   return true;
 }
 
@@ -593,41 +509,6 @@ bool SystemInterface::verify_auxiliary_sensor_() {
       RCLCPP_ERROR_STREAM(get_node()->get_logger(),
                           lbr_fri_ros2::ColorScheme::ERROR
                               << "Sensor '" << auxiliary_sensor.name.c_str()
-                              << "' received invalid state interface '" << si.name.c_str() << "'"
-                              << lbr_fri_ros2::ColorScheme::ENDC);
-      return false;
-    }
-  }
-  return true;
-}
-
-bool SystemInterface::verify_estimated_ft_sensor_() {
-  const auto &estimated_ft_sensor = info_.sensors[1];
-  if (estimated_ft_sensor.name != HW_IF_ESTIMATED_FT_PREFIX) {
-    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                        lbr_fri_ros2::ColorScheme::ERROR
-                            << "Sensor '" << estimated_ft_sensor.name.c_str()
-                            << "' received invalid name. Expected '" << HW_IF_ESTIMATED_FT_PREFIX
-                            << "'" << lbr_fri_ros2::ColorScheme::ENDC);
-    return false;
-  }
-  if (estimated_ft_sensor.state_interfaces.size() != ESTIMATED_FT_SENSOR_SIZE) {
-    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                        lbr_fri_ros2::ColorScheme::ERROR
-                            << "Sensor '" << estimated_ft_sensor.name.c_str()
-                            << "' received invalid number of state interfaces. Received '"
-                            << estimated_ft_sensor.state_interfaces.size() << "', expected '"
-                            << static_cast<int>(ESTIMATED_FT_SENSOR_SIZE) << "'"
-                            << lbr_fri_ros2::ColorScheme::ENDC);
-    return false;
-  }
-  // check only valid interfaces are defined
-  for (const auto &si : estimated_ft_sensor.state_interfaces) {
-    if (si.name != HW_IF_FORCE_X && si.name != HW_IF_FORCE_Y && si.name != HW_IF_FORCE_Z &&
-        si.name != HW_IF_TORQUE_X && si.name != HW_IF_TORQUE_Y && si.name != HW_IF_TORQUE_Z) {
-      RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                          lbr_fri_ros2::ColorScheme::ERROR
-                              << "Sensor '" << estimated_ft_sensor.name.c_str()
                               << "' received invalid state interface '" << si.name.c_str() << "'"
                               << lbr_fri_ros2::ColorScheme::ENDC);
       return false;


### PR DESCRIPTION
Replacement for #319.

The asynchronous FT estimation was initially introduced in https://github.com/lbr-stack/lbr_fri_ros2_stack/releases/tag/humble-v2.2.0. Since the robot, however, doesn't intrinsically provide this interface, it makes more sense to estimate FT from external torques elsewhere (e.g. in the form of a chainable controller).

- [x] Force-torque estimation update #292
  - [x] Remove force-torque estimation from system interface
  - [x] Force-torque estimation as chainable controller. For reference: https://github.com/ros-controls/ros2_controllers/issues/2052
- [x] Turn load check in `lbr_ros2_control::AdmittanceController` configurable #325  
- [x] Tune filtering #327
- [x] Update changelog

Future work on the system interface should

- Remove the `get_state/command` and `set_state/command` lookups introduced in Jazzy with handles to remove overhead
- Only expose command interfaces depending on the `lbr_system_config.yaml` specified command mode