### PR TITLE
Add IO support #198

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,10 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package LBR FRI ROS 2 Stack
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Jazzy v2.4.4 (TBD)
+Jazzy v2.5.0 (TBD)
 --------------------------
+Adds support for digital and analog IOs through FRI. Adds small bug fixes and enhancements.
+
 * ``lbr_bringup``: Adds a dedicated ``namespace`` argument to mock / hardware launch files.
 * ``lbr_description``:
 


### PR DESCRIPTION
To do:

- [ ] Add `io` configurations to [lbr_system_config.yaml](https://github.com/lbr-stack/lbr_fri_ros2_stack/blob/jazzy/lbr_description/ros2_control/lbr_system_config.yaml)
- [ ] Parse `io` configurations via [lbr_system_interface.xacro](https://github.com/lbr-stack/lbr_fri_ros2_stack/blob/jazzy/lbr_description/ros2_control/lbr_system_interface.xacro) to [system_interface.hpp](https://github.com/lbr-stack/lbr_fri_ros2_stack/blob/jazzy/lbr_ros2_control/include/lbr_ros2_control/system_interface.hpp) 
- [ ] Add new type values to [system_interface_type_values.hpp](https://github.com/lbr-stack/lbr_fri_ros2_stack/blob/jazzy/lbr_ros2_control/include/lbr_ros2_control/system_interface_type_values.hpp)
- [ ] Add `io` to IDL https://github.com/lbr-stack/lbr_fri_idl and create releases for older versions of this stack
- [ ] Add `io` read / write to `lbr_fri_ros2` interfaces
- [ ] Check IO support for different FRI versions (add pre-processor directives where unsupported, e.g. FRI 1.11)

Other considerations:

- How does this fit into the bigger picture of dynamically loading the FRI at runtime (to support `rosdistro`)?