### PR TITLE
Fix moveit servo example

### DIFF
--- a/lbr_bringup/lbr_bringup/moveit.py
+++ b/lbr_bringup/lbr_bringup/moveit.py
@@ -141,7 +141,7 @@ class LBRMoveItServoMixin:
     ) -> Node:
         return Node(
             package="moveit_servo",
-            executable="servo_node_main",
+            executable="servo_node",
             output="screen",
             namespace=robot_name,
             **kwargs,

--- a/lbr_demos/lbr_moveit/lbr_moveit/forward_keyboard_node.py
+++ b/lbr_demos/lbr_moveit/lbr_moveit/forward_keyboard_node.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import numpy as np
 import rclpy
@@ -25,8 +25,8 @@ class ForwardKeyboardNode(Node):
             z: float = 0.0
 
         joints: list
-        translation: Translation = Translation()
-        rotation: Rotation = Rotation()
+        translation: Translation = field(default_factory=Translation)
+        rotation: Rotation = field(default_factory=Rotation)
 
     @dataclass
     class KeyboardLayout:
@@ -47,9 +47,9 @@ class ForwardKeyboardNode(Node):
                 increase: str = "q"
                 decrease: str = "e"
 
-            x: X = X()
-            y: Y = Y()
-            z: Z = Z()
+            x: X = field(default_factory=X)
+            y: Y = field(default_factory=Y)
+            z: Z = field(default_factory=Z)
 
         @dataclass
         class Rotation:
@@ -68,13 +68,13 @@ class ForwardKeyboardNode(Node):
                 increase: str = "y"
                 decrease: str = "h"
 
-            x: X = X()
-            y: Y = Y()
-            z: Z = Z()
+            x: X = field(default_factory=X)
+            y: Y = field(default_factory=Y)
+            z: Z = field(default_factory=Z)
 
         joints: list
-        translation: Translation = Translation()
-        rotation: Rotation = Rotation()
+        translation: Translation = field(default_factory=Translation)
+        rotation: Rotation = field(default_factory=Rotation)
         escape: str = "Key.esc"
         pause: str = "p"
         reverse_joints: str = "r"

--- a/lbr_demos/lbr_moveit/package.xml
+++ b/lbr_demos/lbr_moveit/package.xml
@@ -11,6 +11,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <exec_depend>python3-pynput</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
Fixed the MoveIt Servo example, all the parts now run. The demo still does not work however as thre is a bug in Moveit (moveit/moveit2#3040) which is supposed to be fixed but not yet bacported to jazzy.